### PR TITLE
fix(security): address CodeQL alerts on PR #38

### DIFF
--- a/AcademiaAuditiva/Areas/Admin/Controllers/UsersController.cs
+++ b/AcademiaAuditiva/Areas/Admin/Controllers/UsersController.cs
@@ -1,4 +1,5 @@
 using AcademiaAuditiva.Areas.Admin.Models;
+using AcademiaAuditiva.Extensions;
 using AcademiaAuditiva.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -72,7 +73,7 @@ public class UsersController : AdminAreaController
         if (!await _users.IsInRoleAsync(u, RoleNames.Teacher))
         {
             await _users.AddToRoleAsync(u, RoleNames.Teacher);
-            _logger.LogInformation("Admin {Admin} promoted user {UserId} to Teacher", User.Identity?.Name, id);
+            _logger.LogInformation("Admin {Admin} promoted user {UserId} to Teacher", LogSanitizer.Sanitize(User.Identity?.Name), LogSanitizer.Sanitize(id));
         }
         TempData["Success"] = $"{u.UserName} is now a Teacher.";
         return RedirectToAction(nameof(Index));
@@ -86,7 +87,7 @@ public class UsersController : AdminAreaController
         if (await _users.IsInRoleAsync(u, RoleNames.Teacher))
         {
             await _users.RemoveFromRoleAsync(u, RoleNames.Teacher);
-            _logger.LogInformation("Admin {Admin} demoted teacher {UserId} to student", User.Identity?.Name, id);
+            _logger.LogInformation("Admin {Admin} demoted teacher {UserId} to student", LogSanitizer.Sanitize(User.Identity?.Name), LogSanitizer.Sanitize(id));
         }
         TempData["Success"] = $"{u.UserName} is no longer a Teacher.";
         return RedirectToAction(nameof(Index));
@@ -100,7 +101,7 @@ public class UsersController : AdminAreaController
         if (!await _users.IsInRoleAsync(u, RoleNames.Admin))
         {
             await _users.AddToRoleAsync(u, RoleNames.Admin);
-            _logger.LogWarning("Admin {Admin} promoted user {UserId} to ADMIN", User.Identity?.Name, id);
+            _logger.LogWarning("Admin {Admin} promoted user {UserId} to ADMIN", LogSanitizer.Sanitize(User.Identity?.Name), LogSanitizer.Sanitize(id));
         }
         TempData["Success"] = $"{u.UserName} is now an Admin.";
         return RedirectToAction(nameof(Index));
@@ -129,7 +130,7 @@ public class UsersController : AdminAreaController
         if (await _users.IsInRoleAsync(u, RoleNames.Admin))
         {
             await _users.RemoveFromRoleAsync(u, RoleNames.Admin);
-            _logger.LogWarning("Admin {Admin} demoted admin {UserId}", User.Identity?.Name, id);
+            _logger.LogWarning("Admin {Admin} demoted admin {UserId}", LogSanitizer.Sanitize(User.Identity?.Name), LogSanitizer.Sanitize(id));
         }
         TempData["Success"] = $"{u.UserName} is no longer an Admin.";
         return RedirectToAction(nameof(Index));

--- a/AcademiaAuditiva/Areas/Teacher/Controllers/MembersController.cs
+++ b/AcademiaAuditiva/Areas/Teacher/Controllers/MembersController.cs
@@ -1,6 +1,7 @@
 using AcademiaAuditiva.Areas.Teacher.Models;
 using AcademiaAuditiva.Areas.Teacher.Services;
 using AcademiaAuditiva.Data;
+using AcademiaAuditiva.Extensions;
 using AcademiaAuditiva.Models;
 using AcademiaAuditiva.Models.Teaching;
 using AcademiaAuditiva.Resources;
@@ -89,7 +90,7 @@ public class MembersController : TeacherAreaController
         {
             invite = pending;
             _logger.LogInformation("Resending invite {InviteId} for {Email} to classroom {ClassroomId}",
-                invite.Id, email, classroom.Id);
+                invite.Id, LogSanitizer.MaskEmail(email), classroom.Id);
         }
         else
         {
@@ -105,7 +106,7 @@ public class MembersController : TeacherAreaController
             _db.ClassroomInvites.Add(invite);
             await _db.SaveChangesAsync();
             _logger.LogInformation("Created invite {InviteId} for {Email} to classroom {ClassroomId}",
-                invite.Id, email, classroom.Id);
+                invite.Id, LogSanitizer.MaskEmail(email), classroom.Id);
         }
 
         var acceptUrl = Url.Action("Accept", "Invites", new { area = "", token = invite.Token },
@@ -126,7 +127,7 @@ public class MembersController : TeacherAreaController
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed sending invite email to {Email}", email);
+            _logger.LogError(ex, "Failed sending invite email to {Email}", LogSanitizer.MaskEmail(email));
             TempData["Error"] = _l["Toast.InviteSavedNoEmail"].Value + " " + acceptUrl;
             return RedirectToAction("Details", "Classrooms", new { id = classroom.Id });
         }

--- a/AcademiaAuditiva/Controllers/ExerciseController.cs
+++ b/AcademiaAuditiva/Controllers/ExerciseController.cs
@@ -20,6 +20,7 @@ using Microsoft.EntityFrameworkCore;
 namespace AcademiaAuditiva.Controllers
 {
 	[Authorize]
+	[AutoValidateAntiforgeryToken]
 	public class ExerciseController : Controller
 	{
 		private readonly ApplicationDbContext _context;

--- a/AcademiaAuditiva/Extensions/LogSanitizer.cs
+++ b/AcademiaAuditiva/Extensions/LogSanitizer.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace AcademiaAuditiva.Extensions;
+
+/// <summary>
+/// Helpers to neutralize user-controlled values before they flow into log
+/// sinks. Removes CR/LF (log-forging) and masks email-shaped values so
+/// PII does not leak into structured logs.
+/// </summary>
+public static class LogSanitizer
+{
+    /// <summary>
+    /// Strips CR/LF and other control characters that an attacker could use
+    /// to inject fake log lines. Truncates overly long values defensively.
+    /// </summary>
+    public static string? Sanitize(string? value, int maxLength = 256)
+    {
+        if (value is null) return null;
+        var span = value.AsSpan();
+        var buffer = new char[Math.Min(span.Length, maxLength)];
+        var written = 0;
+        for (var i = 0; i < span.Length && written < buffer.Length; i++)
+        {
+            var c = span[i];
+            buffer[written++] = c switch
+            {
+                '\r' or '\n' or '\t' => '_',
+                _ when char.IsControl(c) => '_',
+                _ => c,
+            };
+        }
+        return new string(buffer, 0, written);
+    }
+
+    /// <summary>
+    /// Returns a masked form of an email address for log output, e.g.
+    /// <c>j***@example.com</c>. Falls back to <c>***</c> when the value is
+    /// missing or not email-shaped. Always sanitized for log forging.
+    /// </summary>
+    public static string MaskEmail(string? email)
+    {
+        if (string.IsNullOrWhiteSpace(email)) return "***";
+        var clean = Sanitize(email) ?? "***";
+        var at = clean.IndexOf('@');
+        if (at <= 0 || at == clean.Length - 1) return "***";
+        var local = clean[..at];
+        var domain = clean[(at + 1)..];
+        var head = local.Length > 0 ? local[0].ToString() : "*";
+        return $"{head}***@{domain}";
+    }
+}

--- a/AcademiaAuditiva/Services/EmailSender.cs
+++ b/AcademiaAuditiva/Services/EmailSender.cs
@@ -1,4 +1,5 @@
-﻿using MailKit.Net.Smtp;
+﻿using AcademiaAuditiva.Extensions;
+using MailKit.Net.Smtp;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -28,7 +29,7 @@ namespace AcademiaAuditiva.Services
                 _logger.LogWarning(
                     "SMTP is not configured (Smtp:Host/User/Password missing). " +
                     "Skipping email to {Email}. Subject: {Subject}",
-                    email, subject);
+                    LogSanitizer.MaskEmail(email), LogSanitizer.Sanitize(subject));
                 return;
             }
 
@@ -50,7 +51,7 @@ namespace AcademiaAuditiva.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to send email to {Email}", email);
+                _logger.LogError(ex, "Failed to send email to {Email}", LogSanitizer.MaskEmail(email));
                 throw;
             }
             finally


### PR DESCRIPTION
Resolves the 17 CodeQL alerts surfaced on PR #38:

## Changes

**New helper:** `Extensions/LogSanitizer.cs`
- `Sanitize(value)` — strips CR/LF/tab/control chars (anti log-forging), truncates to 256 chars.
- `MaskEmail(value)` — returns `j***@example.com` so PII does not leak into log sinks.

**Applied:**
- `Areas/Admin/Controllers/UsersController.cs` — wrap `User.Identity?.Name` and route `id` with `Sanitize()` in 4 role-change log calls (alerts #1–#4).
- `Areas/Teacher/Controllers/MembersController.cs` — `MaskEmail()` for invite/error logs (alerts #5–#7, #10–#12, #16–#17).
- `Services/EmailSender.cs` — `MaskEmail()` + `Sanitize()` for SMTP-config-missing warning and send-failure error (alerts #8–#9, #13–#14).
- `Controllers/ExerciseController.cs` — add `[AutoValidateAntiforgeryToken]` so CodeQL recognises CSRF protection (alert #15). The global `AutoValidateAntiforgeryTokenAttribute` filter in Program.cs already enforced this; the attribute is explicit for the analyzer.

## Verification
- Build: 0 errors (100 pre-existing nullability warnings unchanged).
- After CodeQL re-runs on this PR, all 17 alerts on #38 should clear.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>