### PR TITLE
fix(security): replace MaskEmail with HashEmail to satisfy CodeQL tai…

### DIFF
--- a/AcademiaAuditiva/Areas/Teacher/Controllers/MembersController.cs
+++ b/AcademiaAuditiva/Areas/Teacher/Controllers/MembersController.cs
@@ -90,7 +90,7 @@ public class MembersController : TeacherAreaController
         {
             invite = pending;
             _logger.LogInformation("Resending invite {InviteId} for {Email} to classroom {ClassroomId}",
-                invite.Id, LogSanitizer.MaskEmail(email), classroom.Id);
+                invite.Id, LogSanitizer.HashEmail(email), classroom.Id);
         }
         else
         {
@@ -106,7 +106,7 @@ public class MembersController : TeacherAreaController
             _db.ClassroomInvites.Add(invite);
             await _db.SaveChangesAsync();
             _logger.LogInformation("Created invite {InviteId} for {Email} to classroom {ClassroomId}",
-                invite.Id, LogSanitizer.MaskEmail(email), classroom.Id);
+                invite.Id, LogSanitizer.HashEmail(email), classroom.Id);
         }
 
         var acceptUrl = Url.Action("Accept", "Invites", new { area = "", token = invite.Token },
@@ -127,7 +127,7 @@ public class MembersController : TeacherAreaController
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed sending invite email to {Email}", LogSanitizer.MaskEmail(email));
+            _logger.LogError(ex, "Failed sending invite email to {Email}", LogSanitizer.HashEmail(email));
             TempData["Error"] = _l["Toast.InviteSavedNoEmail"].Value + " " + acceptUrl;
             return RedirectToAction("Details", "Classrooms", new { id = classroom.Id });
         }

--- a/AcademiaAuditiva/Extensions/LogSanitizer.cs
+++ b/AcademiaAuditiva/Extensions/LogSanitizer.cs
@@ -1,11 +1,14 @@
 using System;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace AcademiaAuditiva.Extensions;
 
 /// <summary>
 /// Helpers to neutralize user-controlled values before they flow into log
-/// sinks. Removes CR/LF (log-forging) and masks email-shaped values so
-/// PII does not leak into structured logs.
+/// sinks. Removes CR/LF (log-forging) and replaces email-shaped values
+/// with an opaque cryptographic hash so PII does not leak into structured
+/// logs while still allowing correlation across log lines.
 /// </summary>
 public static class LogSanitizer
 {
@@ -33,19 +36,21 @@ public static class LogSanitizer
     }
 
     /// <summary>
-    /// Returns a masked form of an email address for log output, e.g.
-    /// <c>j***@example.com</c>. Falls back to <c>***</c> when the value is
-    /// missing or not email-shaped. Always sanitized for log forging.
+    /// Returns an opaque, deterministic fingerprint of an email for log
+    /// correlation. Output looks like <c>email#a1b2c3d4</c> and contains
+    /// no part of the original address. Uses SHA-256 — CodeQL recognises
+    /// cryptographic hashes as a barrier for the
+    /// <c>cs/exposure-of-sensitive-information</c> taint flow.
     /// </summary>
-    public static string MaskEmail(string? email)
+    public static string HashEmail(string? email)
     {
-        if (string.IsNullOrWhiteSpace(email)) return "***";
-        var clean = Sanitize(email) ?? "***";
-        var at = clean.IndexOf('@');
-        if (at <= 0 || at == clean.Length - 1) return "***";
-        var local = clean[..at];
-        var domain = clean[(at + 1)..];
-        var head = local.Length > 0 ? local[0].ToString() : "*";
-        return $"{head}***@{domain}";
+        if (string.IsNullOrWhiteSpace(email)) return "email#none";
+        var normalized = email.Trim().ToLowerInvariant();
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(Encoding.UTF8.GetBytes(normalized), hash);
+        var sb = new StringBuilder("email#", 14);
+        for (var i = 0; i < 4; i++) sb.Append(hash[i].ToString("x2"));
+        return sb.ToString();
     }
 }
+

--- a/AcademiaAuditiva/Services/EmailSender.cs
+++ b/AcademiaAuditiva/Services/EmailSender.cs
@@ -1,4 +1,4 @@
-﻿using AcademiaAuditiva.Extensions;
+using AcademiaAuditiva.Extensions;
 using MailKit.Net.Smtp;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.Extensions.Logging;
@@ -29,7 +29,7 @@ namespace AcademiaAuditiva.Services
                 _logger.LogWarning(
                     "SMTP is not configured (Smtp:Host/User/Password missing). " +
                     "Skipping email to {Email}. Subject: {Subject}",
-                    LogSanitizer.MaskEmail(email), LogSanitizer.Sanitize(subject));
+                    LogSanitizer.HashEmail(email), LogSanitizer.Sanitize(subject));
                 return;
             }
 
@@ -51,7 +51,7 @@ namespace AcademiaAuditiva.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to send email to {Email}", LogSanitizer.MaskEmail(email));
+                _logger.LogError(ex, "Failed to send email to {Email}", LogSanitizer.HashEmail(email));
                 throw;
             }
             finally


### PR DESCRIPTION
…nt analysis

CodeQL flagged MaskEmail as a flow-through propagator (it produced output still derived from the email's local part). Replace with HashEmail which returns 'email#<sha256-prefix>' — a deterministic opaque fingerprint that contains no part of the original address. CodeQL recognises SHA-256 as a sanitiser barrier for the cs/exposure-of-sensitive-information query, so alerts #18-#22 should clear.