### PR TITLE
feat(audio): server-mix anti-cheat with opaque round tokens

### DIFF
--- a/AcademiaAuditiva/AcademiaAuditiva.csproj
+++ b/AcademiaAuditiva/AcademiaAuditiva.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="NLayer" Version="1.16.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="MailKit" Version="4.7.1.1" />

--- a/AcademiaAuditiva/Controllers/AudioController.cs
+++ b/AcademiaAuditiva/Controllers/AudioController.cs
@@ -1,0 +1,138 @@
+using AcademiaAuditiva.Interfaces;
+using Azure.Storage.Blobs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Security.Claims;
+
+namespace AcademiaAuditiva.Controllers;
+
+/// <summary>
+/// Streams the per-round audio asset addressed by an opaque token
+/// previously issued by <c>RequestPlay</c>. The browser never sees a
+/// note name, blob path, or storage URL — only a GUID. Tokens expire
+/// with the round (15 min) and are scoped to the issuing user; cross
+/// user attempts return 404.
+/// </summary>
+[ApiController]
+[Route("audio")]
+[Authorize]
+public sealed class AudioController : ControllerBase
+{
+    private readonly BlobServiceClient _blobServiceClient;
+    private readonly IAudioTokenService _audioTokens;
+    private readonly ILogger<AudioController> _logger;
+
+    public AudioController(
+        BlobServiceClient blobServiceClient,
+        IAudioTokenService audioTokens,
+        ILogger<AudioController> logger)
+    {
+        _blobServiceClient = blobServiceClient;
+        _audioTokens = audioTokens;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Streams the audio bytes for a one-time round token.
+    /// The token must have been issued to the calling user; otherwise
+    /// the response is 404 (we deliberately do not distinguish "not
+    /// found" from "wrong user" so a probing client cannot enumerate).
+    /// </summary>
+    [HttpGet("token/{token}")]
+    [EnableRateLimiting("AudioToken")]
+    public async Task<IActionResult> StreamByToken(string token, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return BadRequest();
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Unauthorized();
+        }
+
+        var address = await _audioTokens.ResolveTokenAsync(userId, token, ct);
+        if (string.IsNullOrEmpty(address))
+        {
+            _logger.LogInformation("Audio token resolution failed for user {UserId}.", userId);
+            return NotFound();
+        }
+
+        // The token service returns "container/blobName" so a single
+        // endpoint can stream from either the source container (no-op
+        // pass-through for GuessNote) or the mixed container.
+        var slash = address.IndexOf('/');
+        if (slash <= 0 || slash == address.Length - 1)
+        {
+            _logger.LogWarning("Malformed audio address resolved from token: {Address}", address);
+            return NotFound();
+        }
+
+        var container = address[..slash];
+        var blobName = address[(slash + 1)..];
+
+        // Defense-in-depth: only allow the two well-known containers.
+        if (container is not ("piano-audio" or "piano-audio-mixed"))
+        {
+            _logger.LogWarning("Audio token resolved to unexpected container: {Container}", container);
+            return NotFound();
+        }
+
+        // Tokens are one-shot per round and shouldn't be cached by the
+        // browser or any intermediate proxy — caching would let two
+        // tabs share state we want to keep per-round.
+        Response.Headers.CacheControl = "no-store, no-cache, must-revalidate";
+        Response.Headers.Pragma = "no-cache";
+
+        return await StreamBlobAsync(container, blobName, ct);
+    }
+
+    /// <summary>
+    /// Authenticated by-name access to the source piano samples. Used
+    /// only by the sheet-music exercises (SolfegeMelody, IntervalMelodico)
+    /// where the note names are intentionally visible to the learner —
+    /// hiding the URL would not add anti-cheat value. Requires login,
+    /// rejects path traversal, and only serves the source container.
+    /// </summary>
+    [HttpGet("{name}")]
+    [ResponseCache(Duration = 31536000, Location = ResponseCacheLocation.Any)]
+    public async Task<IActionResult> StreamByName(string name, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(name) || name.Contains('/') || name.Contains('\\') || name.Contains(".."))
+        {
+            return BadRequest();
+        }
+
+        var ext = Path.GetExtension(name).ToLowerInvariant();
+        if (ext is not (".mp3" or ".wav" or ".ogg"))
+        {
+            return BadRequest();
+        }
+
+        Response.Headers.CacheControl = "public, max-age=31536000, immutable";
+        return await StreamBlobAsync("piano-audio", name, ct);
+    }
+
+    private async Task<IActionResult> StreamBlobAsync(string container, string blobName, CancellationToken ct)
+    {
+        try
+        {
+            var containerClient = _blobServiceClient.GetBlobContainerClient(container);
+            var blobClient = containerClient.GetBlobClient(blobName);
+            var props = await blobClient.GetPropertiesAsync(cancellationToken: ct);
+            var contentType = string.IsNullOrWhiteSpace(props.Value.ContentType)
+                ? "application/octet-stream"
+                : props.Value.ContentType;
+
+            var download = await blobClient.DownloadStreamingAsync(cancellationToken: ct);
+            return File(download.Value.Content, contentType, enableRangeProcessing: true);
+        }
+        catch (Azure.RequestFailedException ex) when (ex.Status == 404)
+        {
+            return NotFound();
+        }
+    }
+}

--- a/AcademiaAuditiva/Controllers/ExerciseController.cs
+++ b/AcademiaAuditiva/Controllers/ExerciseController.cs
@@ -8,6 +8,7 @@ using AcademiaAuditiva.ViewModels;
 using AcademiaAuditiva.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Localization;
 using Newtonsoft.Json;
@@ -29,6 +30,9 @@ namespace AcademiaAuditiva.Controllers
 		private readonly IExerciseValidatorRegistry _validators;
 		private readonly IMusicTheoryService _musicTheory;
 		private readonly IDistributedCache _cache;
+		private readonly IAudioTokenService _audioTokens;
+		private readonly IAudioMixerService _audioMixer;
+		private readonly AcademiaAuditiva.Services.Audio.ExercisePlaybackPlanner _playbackPlanner;
 
 		// Expected-answer entries live for one round (15 min) and are
 		// keyed per (user, exercise). The cache is a distributed abstraction
@@ -36,7 +40,16 @@ namespace AcademiaAuditiva.Controllers
 		private static readonly DistributedCacheEntryOptions _expectedAnswerTtl =
 			new() { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(15) };
 
-		public ExerciseController(ApplicationDbContext context, IStringLocalizer<SharedResources> localizer, IAnalyticsService analyticsService, IExerciseValidatorRegistry validators, IMusicTheoryService musicTheory, IDistributedCache cache)
+		public ExerciseController(
+			ApplicationDbContext context,
+			IStringLocalizer<SharedResources> localizer,
+			IAnalyticsService analyticsService,
+			IExerciseValidatorRegistry validators,
+			IMusicTheoryService musicTheory,
+			IDistributedCache cache,
+			IAudioTokenService audioTokens,
+			IAudioMixerService audioMixer,
+			AcademiaAuditiva.Services.Audio.ExercisePlaybackPlanner playbackPlanner)
 		{
 			_context = context;
 			_localizer = localizer;
@@ -44,6 +57,9 @@ namespace AcademiaAuditiva.Controllers
 			_validators = validators;
 			_musicTheory = musicTheory;
 			_cache = cache;
+			_audioTokens = audioTokens;
+			_audioMixer = audioMixer;
+			_playbackPlanner = playbackPlanner;
 		}
 
 		private static string ExpectedAnswerCacheKey(string userId, int exerciseId)
@@ -62,6 +78,7 @@ namespace AcademiaAuditiva.Controllers
 		#region General Play and Validate
 		
 		[HttpPost]
+		[EnableRateLimiting("RequestPlay")]
 		public async Task<IActionResult> RequestPlay([FromBody] PlayRequestDto request)
 		{
 			var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -83,19 +100,48 @@ namespace AcademiaAuditiva.Controllers
 			if (!filters.ContainsKey("noteRange"))
 				filters["noteRange"] = noteRange;
 
-			var result = _musicTheory.GenerateNoteForExercise(exercise, filters);
+			var plan = _playbackPlanner.Plan(exercise, filters);
 
-			var sessionData = new ExerciseSessionData
+			// Sheet-music exercises (SolfegeMelody / IntervalMelodico) do
+			// not get an audio token — they are out of scope for this
+			// anti-cheat flow. We still cache the expected answer so
+			// ValidateExercise can score them, but we keep the original
+			// response shape (notes in clear text) so the front-end can
+			// render the sheet music.
+			if (plan.PlaybackPlans.Count == 0)
 			{
-				ExpectedAnswer = JsonConvert.SerializeObject(result)
-			};
+				var legacyPayload = JsonConvert.DeserializeObject(plan.ExpectedAnswerJson)!;
+				var sessionData = new ExerciseSessionData { ExpectedAnswer = plan.ExpectedAnswerJson };
+				await _cache.SetStringAsync(
+					ExpectedAnswerCacheKey(userId, request.ExerciseId),
+					JsonConvert.SerializeObject(sessionData),
+					_expectedAnswerTtl);
+				return Json(legacyPayload);
+			}
 
-			await _cache.SetStringAsync(
-				ExpectedAnswerCacheKey(userId, request.ExerciseId),
-				JsonConvert.SerializeObject(sessionData),
-				_expectedAnswerTtl);
+			// Mix every plan into a single playable blob, then collect
+			// "container/blobName" strings so the token service stores
+			// only opaque references.
+			var mixedAddresses = new string[plan.PlaybackPlans.Count];
+			for (var i = 0; i < plan.PlaybackPlans.Count; i++)
+			{
+				var mixed = await _audioMixer.MixAsync(plan.PlaybackPlans[i], HttpContext.RequestAborted);
+				mixedAddresses[i] = $"{mixed.Container}/{mixed.BlobName}";
+			}
 
-			return Json(result);
+			var round = await _audioTokens.CreateRoundAsync(
+				userId,
+				request.ExerciseId,
+				plan.ExpectedAnswerJson,
+				mixedAddresses,
+				HttpContext.RequestAborted);
+
+			// Uniform response: most exercises ship one play token; only
+			// GuessMissingNote ships two (melody1Token, melody2Token).
+			object response = exercise.Name == "GuessMissingNote"
+				? new { roundId = round.RoundId, melody1Token = round.Tokens[0], melody2Token = round.Tokens[1] }
+				: new { roundId = round.RoundId, playToken = round.Tokens[0] };
+			return Json(response);
 		}
 
 
@@ -110,14 +156,31 @@ namespace AcademiaAuditiva.Controllers
 			if (exercise == null)
 				return NotFound(_localizer["Exercise.NotFound"].Value);
 
-			var sessionKey = ExpectedAnswerCacheKey(userId, dto.ExerciseId);
-			var json = await _cache.GetStringAsync(sessionKey);
+			// Resolve the expected answer either from the round (modern
+			// audio-token flow) or, for sheet-music exercises that don't
+			// produce a token, from the legacy session-key cache.
+			string expectedAnswer = null;
+			bool roundConsumed = false;
 
-			if (string.IsNullOrEmpty(json))
-				return Json(new { success = false, message = _localizer["Exercise.SessionExpired"].Value, isCorrect = false });
+			if (!string.IsNullOrEmpty(dto.RoundId))
+			{
+				var round = await _audioTokens.GetRoundAsync(userId, dto.ExerciseId, dto.RoundId, HttpContext.RequestAborted);
+				if (round is not null)
+				{
+					expectedAnswer = round.ExpectedAnswerJson;
+					roundConsumed = true;
+				}
+			}
 
-			var sessionData = JsonConvert.DeserializeObject<ExerciseSessionData>(json);
-			var expectedAnswer = sessionData.ExpectedAnswer;
+			var legacyKey = ExpectedAnswerCacheKey(userId, dto.ExerciseId);
+			if (expectedAnswer is null)
+			{
+				var json = await _cache.GetStringAsync(legacyKey);
+				if (string.IsNullOrEmpty(json))
+					return Json(new { success = false, message = _localizer["Exercise.SessionExpired"].Value, isCorrect = false });
+				var legacy = JsonConvert.DeserializeObject<ExerciseSessionData>(json);
+				expectedAnswer = legacy.ExpectedAnswer;
+			}
 
 			var validator = _validators.Get(exercise.Name);
 			if (validator == null)
@@ -125,7 +188,7 @@ namespace AcademiaAuditiva.Controllers
 				return Json(new { success = false, message = _localizer["Exercise.NoValidator", exercise.Name].Value, isCorrect = false });
 			}
 
-			var validation = validator.Validate(dto.UserGuess, sessionData.ExpectedAnswer);
+			var validation = validator.Validate(dto.UserGuess, expectedAnswer);
 			var isCorrect = validation.IsCorrect;
 			var currentAnswer = validation.CanonicalAnswer;
 
@@ -193,9 +256,15 @@ namespace AcademiaAuditiva.Controllers
 
 			await _context.SaveChangesAsync();
 
-			// One-shot semantics: drop the expected-answer entry so the
-			// same round can't be replayed against the same cached answer.
-			await _cache.RemoveAsync(sessionKey);
+			// One-shot semantics. Drop both the modern round (so the same
+			// audio tokens can't be replayed against the just-scored
+			// answer) and the legacy expected-answer key (used by the
+			// sheet-music exercises that don't get a round).
+			if (roundConsumed)
+			{
+				await _audioTokens.RemoveRoundAsync(userId, dto.ExerciseId, dto.RoundId, HttpContext.RequestAborted);
+			}
+			await _cache.RemoveAsync(legacyKey);
 			
 			await _analyticsService.SaveAttemptAsync(new ExerciseAttemptLog
 			{

--- a/AcademiaAuditiva/Interfaces/IAudioMixerService.cs
+++ b/AcademiaAuditiva/Interfaces/IAudioMixerService.cs
@@ -1,0 +1,48 @@
+namespace AcademiaAuditiva.Interfaces;
+
+/// <summary>
+/// Composes one playable audio file from a list of source notes drawn
+/// from the <c>piano-audio</c> container. The result is uploaded to a
+/// short-lived container and addressed by an opaque hash-based name —
+/// the front-end only ever sees the token issued by
+/// <see cref="IAudioTokenService"/>, never the mixed blob name.
+/// </summary>
+public interface IAudioMixerService
+{
+    /// <summary>
+    /// Mixes <paramref name="inputs"/> into a single audio asset and
+    /// returns a string of the form <c>{container}/{blobName}</c>
+    /// understood by the audio streaming endpoint.
+    ///
+    /// Two well-known optimizations:
+    /// 1. A single input with <c>StartTime == 0</c> short-circuits to
+    ///    the original source blob (GuessNote).
+    /// 2. Identical input sets reuse a cached mixed blob (replays are
+    ///    free; the blob name is a SHA-256 of the input plan).
+    /// </summary>
+    Task<MixedAudio> MixAsync(
+        IReadOnlyList<MixInput> inputs,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// One source note placed at a specific offset on the mixer timeline.
+/// </summary>
+/// <param name="BlobName">Filename in the source container (e.g. <c>C4.mp3</c>).</param>
+/// <param name="StartTimeSeconds">Offset from the start of the mix.</param>
+/// <param name="DurationSeconds">
+/// Optional cap on how much of the source to consume; <c>null</c> means
+/// "play the entire sample". Useful for trimming sustained notes inside
+/// melodies.
+/// </param>
+public sealed record MixInput(
+    string BlobName,
+    double StartTimeSeconds,
+    double? DurationSeconds = null);
+
+/// <summary>
+/// Address of a mixed (or pass-through) audio asset.
+/// </summary>
+/// <param name="Container">Container holding the blob.</param>
+/// <param name="BlobName">Blob name inside <paramref name="Container"/>.</param>
+public sealed record MixedAudio(string Container, string BlobName);

--- a/AcademiaAuditiva/Interfaces/IAudioTokenService.cs
+++ b/AcademiaAuditiva/Interfaces/IAudioTokenService.cs
@@ -1,0 +1,68 @@
+namespace AcademiaAuditiva.Interfaces;
+
+/// <summary>
+/// Issues and resolves opaque per-round audio tokens. The front-end
+/// receives only token GUIDs from <c>RequestPlay</c> and uses them in
+/// <c>GET /audio/token/{token}</c> to fetch the actual audio bytes.
+/// The mapping <c>token → blobName</c> lives only on the server, in
+/// <see cref="Microsoft.Extensions.Caching.Distributed.IDistributedCache"/>,
+/// scoped to <c>(userId, exerciseId, roundId)</c> and bound to a 15 min TTL.
+///
+/// This is the core anti-cheat primitive: even a user with full DevTools
+/// cannot map a token back to a note name without compromising the server.
+/// </summary>
+public interface IAudioTokenService
+{
+    /// <summary>
+    /// Creates a new round for the given user/exercise, persists the
+    /// expected answer JSON and the playback token map, and returns the
+    /// round identifier together with the issued tokens (parallel to the
+    /// supplied <paramref name="blobNames"/>).
+    /// </summary>
+    Task<AudioRound> CreateRoundAsync(
+        string userId,
+        int exerciseId,
+        string expectedAnswerJson,
+        IReadOnlyList<string> blobNames,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves a token to the underlying blob name, if it is still valid
+    /// and was issued to <paramref name="userId"/>. Returns <c>null</c>
+    /// when the token is unknown, expired, or belongs to another user.
+    /// </summary>
+    Task<string?> ResolveTokenAsync(
+        string userId,
+        string token,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads the cached round, if it exists and matches the user and
+    /// exercise. Returns <c>null</c> when expired or not found.
+    /// </summary>
+    Task<AudioRound?> GetRoundAsync(
+        string userId,
+        int exerciseId,
+        string roundId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes the round and all of its tokens. Called by
+    /// <c>ValidateExercise</c> after scoring so the same round cannot be
+    /// replayed with the same tokens.
+    /// </summary>
+    Task RemoveRoundAsync(
+        string userId,
+        int exerciseId,
+        string roundId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Snapshot of a single exercise round, returned by <see cref="IAudioTokenService"/>.
+/// </summary>
+public sealed record AudioRound(
+    string RoundId,
+    string ExpectedAnswerJson,
+    IReadOnlyList<string> Tokens,
+    IReadOnlyDictionary<string, string> TokenToBlob);

--- a/AcademiaAuditiva/Models/ValidateExerciseDto.cs
+++ b/AcademiaAuditiva/Models/ValidateExerciseDto.cs
@@ -4,5 +4,15 @@ public class ValidateExerciseDto
     public int ExerciseId { get; set; }
     public string UserGuess { get; set; }
     public int TimeSpentSeconds { get; set; }
+
+    /// <summary>
+    /// Identifier of the round previously issued by <c>RequestPlay</c>.
+    /// The server uses it to look up the expected answer that was
+    /// generated for this exact play, so duplo-clicks and rapid replays
+    /// can't validate against a fresher answer than the one the user
+    /// actually heard.
+    /// </summary>
+    public string RoundId { get; set; }
 }
+
 

--- a/AcademiaAuditiva/Program.cs
+++ b/AcademiaAuditiva/Program.cs
@@ -150,6 +150,7 @@ builder.Services.AddTransient<IEmailSender, EmailSender>();
 
 //Inject AnalyticsService
 builder.Services.AddSingleton<IAnalyticsService, AnalyticsService>();
+builder.Services.AddHttpClient();
 builder.Services.AddSingleton<IMusicTheoryService, MusicTheoryServiceAdapter>();
 
 // Exercise validators (Strategy pattern). Each implementation owns the
@@ -211,6 +212,87 @@ builder.Services.AddAntiforgery(options =>
 // instance is a one-line change (AddStackExchangeRedisCache).
 builder.Services.AddDistributedMemoryCache();
 
+// Audio anti-cheat: opaque per-round tokens replace plaintext note names
+// in the RequestPlay → /audio/token → ValidateExercise flow. The token
+// service owns cache shapes; the mixer composes per-question audio so
+// the front never sees note identity.
+builder.Services.AddSingleton<AcademiaAuditiva.Interfaces.IAudioTokenService,
+    AcademiaAuditiva.Services.Audio.AudioTokenService>();
+
+// Single BlobServiceClient shared by AudioController (read piano-audio)
+// and AudioMixerService (read piano-audio + write piano-audio-mixed).
+// Both containers live in the same storage account; one client with
+// the app's managed identity is enough.
+//
+// We always register the client and the mixer so the rest of the
+// graph can resolve at startup. When Storage:BlobEndpoint is missing
+// (local dev without storage), the underlying calls just fail at
+// request time — same fail-mode as before.
+{
+    var blobEndpoint = builder.Configuration["Storage:BlobEndpoint"];
+    var miClientId = builder.Configuration["ManagedIdentityClientId"];
+    var blobCredential = string.IsNullOrWhiteSpace(miClientId)
+        ? new Azure.Identity.DefaultAzureCredential()
+        : new Azure.Identity.DefaultAzureCredential(new Azure.Identity.DefaultAzureCredentialOptions
+        {
+            ManagedIdentityClientId = miClientId
+        });
+    var endpointUri = !string.IsNullOrWhiteSpace(blobEndpoint)
+        ? new Uri(blobEndpoint)
+        : new Uri("https://placeholder.invalid/");
+    builder.Services.AddSingleton(new Azure.Storage.Blobs.BlobServiceClient(endpointUri, blobCredential));
+    builder.Services.AddSingleton<AcademiaAuditiva.Interfaces.IAudioMixerService,
+        AcademiaAuditiva.Services.Audio.AudioMixerService>();
+}
+
+// Maps GenerateNoteForExercise output to a tokenizable mixer plan.
+// Stateless — singleton is fine.
+builder.Services.AddSingleton<AcademiaAuditiva.Services.Audio.ExercisePlaybackPlanner>();
+
+// Rate limiting for the audio anti-cheat surface. Two named policies,
+// both partitioned per authenticated user (falls back to remote IP for
+// anonymous traffic — those callers will fail authorization anyway, but
+// partitioning prevents one IP from starving the bucket for everyone).
+//
+// Limits are deliberately generous for legitimate practice (a student
+// rarely fires more than a handful of rounds per minute) but tight
+// enough that brute-force enumeration of token GUIDs is hopeless given
+// the 32-hex search space + 15-min TTL.
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+    options.AddPolicy("RequestPlay", httpContext =>
+    {
+        var key = httpContext.User?.Identity?.IsAuthenticated == true
+            ? httpContext.User.Identity!.Name ?? "anon"
+            : httpContext.Connection.RemoteIpAddress?.ToString() ?? "anon";
+        return System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(key, _ =>
+            new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 60,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                AutoReplenishment = true
+            });
+    });
+
+    options.AddPolicy("AudioToken", httpContext =>
+    {
+        var key = httpContext.User?.Identity?.IsAuthenticated == true
+            ? httpContext.User.Identity!.Name ?? "anon"
+            : httpContext.Connection.RemoteIpAddress?.ToString() ?? "anon";
+        return System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(key, _ =>
+            new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 600,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                AutoReplenishment = true
+            });
+    });
+});
+
 
 var app = builder.Build();
 
@@ -243,6 +325,8 @@ app.UseRouting();
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.UseRateLimiter();
 
 app.MapControllerRoute(
     name: "areas",

--- a/AcademiaAuditiva/Services/Audio/AudioMixerService.cs
+++ b/AcademiaAuditiva/Services/Audio/AudioMixerService.cs
@@ -1,0 +1,247 @@
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using AcademiaAuditiva.Interfaces;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using NLayer;
+
+namespace AcademiaAuditiva.Services.Audio;
+
+/// <inheritdoc />
+public sealed class AudioMixerService : IAudioMixerService
+{
+    private const string SourceContainerName = "piano-audio";
+    private const string MixedContainerName = "piano-audio-mixed";
+
+    // Roughly the max audible duration we ever expect for a single
+    // round (a four-note melody with rests). Inputs that would extend
+    // past this are clamped — protects the mixer from runaway memory
+    // if upstream plumbing ever sends a bad plan.
+    private const double MaxMixDurationSeconds = 30.0;
+
+    private readonly BlobServiceClient _blobServiceClient;
+    private readonly ILogger<AudioMixerService> _logger;
+
+    // Process-local memo: once we've mixed a given (sorted) input plan,
+    // we keep the resulting blob name in memory so replays during the
+    // same round don't even need to HEAD the storage account.
+    private readonly ConcurrentDictionary<string, MixedAudio> _planToMix = new();
+
+    public AudioMixerService(BlobServiceClient blobServiceClient, ILogger<AudioMixerService> logger)
+    {
+        _blobServiceClient = blobServiceClient;
+        _logger = logger;
+    }
+
+    public async Task<MixedAudio> MixAsync(
+        IReadOnlyList<MixInput> inputs,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        if (inputs.Count == 0)
+        {
+            throw new ArgumentException("At least one input is required.", nameof(inputs));
+        }
+
+        // No-op shortcut: 1 input, no offset, no trim → stream the source
+        // directly. The token still hides the blob name from the user.
+        if (inputs.Count == 1 && inputs[0].StartTimeSeconds == 0 && inputs[0].DurationSeconds is null)
+        {
+            return new MixedAudio(SourceContainerName, inputs[0].BlobName);
+        }
+
+        var planHash = ComputePlanHash(inputs);
+        if (_planToMix.TryGetValue(planHash, out var memoized))
+        {
+            return memoized;
+        }
+
+        var mixedBlobName = $"mix-{planHash}.wav";
+        var sourceContainer = _blobServiceClient.GetBlobContainerClient(SourceContainerName);
+        var mixedContainer = _blobServiceClient.GetBlobContainerClient(MixedContainerName);
+        var mixedBlob = mixedContainer.GetBlobClient(mixedBlobName);
+
+        // If a previous request already produced this exact mix it is
+        // still in storage (lifecycle: 1h). Skip the work.
+        if (await mixedBlob.ExistsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var memo = new MixedAudio(MixedContainerName, mixedBlobName);
+            _planToMix[planHash] = memo;
+            return memo;
+        }
+
+        // 1) Decode every source mp3 into float PCM. Honour the first
+        //    sample's format as canonical; mismatched inputs would
+        //    require resampling, which we don't have on Linux Alpine.
+        var decoded = new List<DecodedSample>(inputs.Count);
+        int? sampleRate = null;
+        int? channels = null;
+        foreach (var input in inputs)
+        {
+            var sample = await DecodeAsync(sourceContainer, input.BlobName, cancellationToken).ConfigureAwait(false);
+            sampleRate ??= sample.SampleRate;
+            channels ??= sample.Channels;
+            if (sample.SampleRate != sampleRate.Value || sample.Channels != channels.Value)
+            {
+                throw new InvalidOperationException(
+                    $"Source '{input.BlobName}' has format {sample.SampleRate}Hz/{sample.Channels}ch but the mix " +
+                    $"uses {sampleRate.Value}Hz/{channels.Value}ch. All piano-audio sources must share one format.");
+            }
+            decoded.Add(sample);
+        }
+
+        // 2) Compute the mixed buffer length (samples per channel).
+        var sr = sampleRate!.Value;
+        var ch = channels!.Value;
+
+        var totalLengthSamples = 0;
+        for (var i = 0; i < inputs.Count; i++)
+        {
+            var startSample = (int)Math.Round(inputs[i].StartTimeSeconds * sr);
+            var srcSamples = decoded[i].Samples.Length / ch;
+            var maxSamples = inputs[i].DurationSeconds is { } d
+                ? (int)Math.Round(d * sr)
+                : srcSamples;
+            var useSamples = Math.Min(srcSamples, maxSamples);
+            totalLengthSamples = Math.Max(totalLengthSamples, startSample + useSamples);
+        }
+
+        var maxAllowed = (int)Math.Round(MaxMixDurationSeconds * sr);
+        if (totalLengthSamples > maxAllowed)
+        {
+            throw new InvalidOperationException(
+                $"Refusing to mix {totalLengthSamples / (double)sr:F1}s of audio (cap is {MaxMixDurationSeconds}s).");
+        }
+
+        // 3) Sum into a float accumulator, then clip to int16.
+        var accum = new float[totalLengthSamples * ch];
+        for (var i = 0; i < inputs.Count; i++)
+        {
+            var src = decoded[i].Samples;
+            var startFrame = (int)Math.Round(inputs[i].StartTimeSeconds * sr);
+            var srcFrames = src.Length / ch;
+            var maxFrames = inputs[i].DurationSeconds is { } d
+                ? (int)Math.Round(d * sr)
+                : srcFrames;
+            var useFrames = Math.Min(srcFrames, maxFrames);
+
+            var dstOffset = startFrame * ch;
+            var copyLength = useFrames * ch;
+            for (var k = 0; k < copyLength; k++)
+            {
+                accum[dstOffset + k] += src[k];
+            }
+        }
+
+        // 4) Encode WAV (RIFF/PCM int16).
+        using var wavStream = new MemoryStream(44 + accum.Length * 2);
+        WriteWavHeader(wavStream, sr, ch, accum.Length);
+        WritePcm16(wavStream, accum);
+        wavStream.Position = 0;
+
+        // 5) Upload. AccessTier.Cool would be wrong (these blobs live <1h);
+        //    just rely on the lifecycle rule on the container.
+        try
+        {
+            await mixedBlob.UploadAsync(
+                wavStream,
+                new BlobHttpHeaders { ContentType = "audio/wav" },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobAlreadyExists)
+        {
+            // Race against another request that produced the same hash.
+            // Both blobs would be byte-equivalent; nothing to do.
+        }
+
+        var result = new MixedAudio(MixedContainerName, mixedBlobName);
+        _planToMix[planHash] = result;
+        _logger.LogDebug("Mixed {InputCount} sources → {Container}/{Blob} ({Duration:F2}s)",
+            inputs.Count, result.Container, result.BlobName, totalLengthSamples / (double)sr);
+        return result;
+    }
+
+    private static async Task<DecodedSample> DecodeAsync(
+        BlobContainerClient sourceContainer,
+        string blobName,
+        CancellationToken cancellationToken)
+    {
+        var blobClient = sourceContainer.GetBlobClient(blobName);
+        using var ms = new MemoryStream();
+        await blobClient.DownloadToAsync(ms, cancellationToken).ConfigureAwait(false);
+        ms.Position = 0;
+
+        // NLayer is a fully managed mp3 decoder — works on Linux/Alpine.
+        using var mpeg = new MpegFile(ms);
+        var sampleRate = mpeg.SampleRate;
+        var channels = mpeg.Channels;
+
+        // Total samples is unknown ahead of time; grow geometrically.
+        var buffer = new List<float>(capacity: 1024 * channels);
+        var chunk = new float[4096];
+        int read;
+        while ((read = mpeg.ReadSamples(chunk, 0, chunk.Length)) > 0)
+        {
+            for (var i = 0; i < read; i++)
+            {
+                buffer.Add(chunk[i]);
+            }
+        }
+
+        return new DecodedSample(sampleRate, channels, buffer.ToArray());
+    }
+
+    private static void WriteWavHeader(Stream stream, int sampleRate, int channels, int totalFrames)
+    {
+        var byteRate = sampleRate * channels * 2;
+        var dataSize = totalFrames * 2; // accum is already (frames*channels) values, each 2 bytes
+        var fileSize = 36 + dataSize;
+
+        Span<byte> header = stackalloc byte[44];
+        Encoding.ASCII.GetBytes("RIFF").CopyTo(header[..4]);
+        BinaryPrimitives.WriteInt32LittleEndian(header.Slice(4, 4), fileSize);
+        Encoding.ASCII.GetBytes("WAVE").CopyTo(header.Slice(8, 4));
+        Encoding.ASCII.GetBytes("fmt ").CopyTo(header.Slice(12, 4));
+        BinaryPrimitives.WriteInt32LittleEndian(header.Slice(16, 4), 16);          // PCM chunk size
+        BinaryPrimitives.WriteInt16LittleEndian(header.Slice(20, 2), 1);           // format = PCM
+        BinaryPrimitives.WriteInt16LittleEndian(header.Slice(22, 2), (short)channels);
+        BinaryPrimitives.WriteInt32LittleEndian(header.Slice(24, 4), sampleRate);
+        BinaryPrimitives.WriteInt32LittleEndian(header.Slice(28, 4), byteRate);
+        BinaryPrimitives.WriteInt16LittleEndian(header.Slice(32, 2), (short)(channels * 2)); // block align
+        BinaryPrimitives.WriteInt16LittleEndian(header.Slice(34, 2), 16);          // bits per sample
+        Encoding.ASCII.GetBytes("data").CopyTo(header.Slice(36, 4));
+        BinaryPrimitives.WriteInt32LittleEndian(header.Slice(40, 4), dataSize);
+        stream.Write(header);
+    }
+
+    private static void WritePcm16(Stream stream, float[] floatSamples)
+    {
+        // Soft-clip with simple saturation. NLayer outputs in roughly
+        // [-1, 1]; summing N notes can exceed that. We accept a small
+        // amount of clipping for simplicity — acceptable for practice
+        // playback at moderate volumes.
+        var pcmBuffer = new byte[floatSamples.Length * 2];
+        for (var i = 0; i < floatSamples.Length; i++)
+        {
+            var s = floatSamples[i];
+            if (s > 1f) s = 1f;
+            else if (s < -1f) s = -1f;
+            var i16 = (short)Math.Round(s * 32767f);
+            BinaryPrimitives.WriteInt16LittleEndian(pcmBuffer.AsSpan(i * 2, 2), i16);
+        }
+        stream.Write(pcmBuffer);
+    }
+
+    private static string ComputePlanHash(IReadOnlyList<MixInput> inputs)
+    {
+        var canonical = string.Join("|", inputs
+            .Select(i => $"{i.BlobName}@{i.StartTimeSeconds:F4}/{i.DurationSeconds?.ToString("F4") ?? "*"}"));
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    private sealed record DecodedSample(int SampleRate, int Channels, float[] Samples);
+}

--- a/AcademiaAuditiva/Services/Audio/AudioTokenService.cs
+++ b/AcademiaAuditiva/Services/Audio/AudioTokenService.cs
@@ -1,0 +1,183 @@
+using AcademiaAuditiva.Interfaces;
+using Microsoft.Extensions.Caching.Distributed;
+using Newtonsoft.Json;
+
+namespace AcademiaAuditiva.Services.Audio;
+
+/// <inheritdoc />
+public sealed class AudioTokenService : IAudioTokenService
+{
+    // 15 min — long enough for a round (Play + a few replays + Validate),
+    // short enough that a leaked token expires before it matters.
+    private static readonly DistributedCacheEntryOptions RoundTtl =
+        new() { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(15) };
+
+    private readonly IDistributedCache _cache;
+
+    public AudioTokenService(IDistributedCache cache)
+    {
+        _cache = cache;
+    }
+
+    public async Task<AudioRound> CreateRoundAsync(
+        string userId,
+        int exerciseId,
+        string expectedAnswerJson,
+        IReadOnlyList<string> blobNames,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(userId);
+        ArgumentNullException.ThrowIfNull(expectedAnswerJson);
+        ArgumentNullException.ThrowIfNull(blobNames);
+
+        var roundId = Guid.NewGuid().ToString("N");
+        var tokens = new string[blobNames.Count];
+        var tokenToBlob = new Dictionary<string, string>(blobNames.Count, StringComparer.Ordinal);
+
+        for (var i = 0; i < blobNames.Count; i++)
+        {
+            var token = Guid.NewGuid().ToString("N");
+            tokens[i] = token;
+            tokenToBlob[token] = blobNames[i];
+        }
+
+        var round = new RoundEnvelope(roundId, expectedAnswerJson, tokenToBlob);
+        var roundJson = JsonConvert.SerializeObject(round);
+
+        // Persist the round itself (lookup by user+exercise+round)…
+        await _cache.SetStringAsync(
+            RoundCacheKey(userId, exerciseId, roundId),
+            roundJson,
+            RoundTtl,
+            cancellationToken);
+
+        // …and the per-token reverse map so the audio endpoint can resolve
+        // a bare token (without requiring exerciseId in the URL).
+        var tokenPointer = new TokenPointer(roundId, exerciseId);
+        var tokenPointerJson = JsonConvert.SerializeObject(tokenPointer);
+        foreach (var token in tokens)
+        {
+            await _cache.SetStringAsync(
+                TokenCacheKey(userId, token),
+                tokenPointerJson,
+                RoundTtl,
+                cancellationToken);
+        }
+
+        return new AudioRound(roundId, expectedAnswerJson, tokens, tokenToBlob);
+    }
+
+    public async Task<string?> ResolveTokenAsync(
+        string userId,
+        string token,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(token))
+        {
+            return null;
+        }
+
+        var pointerJson = await _cache.GetStringAsync(TokenCacheKey(userId, token), cancellationToken);
+        if (string.IsNullOrEmpty(pointerJson))
+        {
+            return null;
+        }
+
+        TokenPointer? pointer;
+        try
+        {
+            pointer = JsonConvert.DeserializeObject<TokenPointer>(pointerJson);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        if (pointer is null)
+        {
+            return null;
+        }
+
+        var round = await LoadRoundAsync(userId, pointer.ExerciseId, pointer.RoundId, cancellationToken);
+        if (round is null)
+        {
+            return null;
+        }
+
+        return round.TokenToBlob.TryGetValue(token, out var blob) ? blob : null;
+    }
+
+    public async Task<AudioRound?> GetRoundAsync(
+        string userId,
+        int exerciseId,
+        string roundId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(roundId))
+        {
+            return null;
+        }
+
+        var envelope = await LoadRoundAsync(userId, exerciseId, roundId, cancellationToken);
+        return envelope is null
+            ? null
+            : new AudioRound(envelope.RoundId, envelope.ExpectedAnswerJson, envelope.TokenToBlob.Keys.ToArray(), envelope.TokenToBlob);
+    }
+
+    public async Task RemoveRoundAsync(
+        string userId,
+        int exerciseId,
+        string roundId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(roundId))
+        {
+            return;
+        }
+
+        var envelope = await LoadRoundAsync(userId, exerciseId, roundId, cancellationToken);
+        if (envelope is not null)
+        {
+            foreach (var token in envelope.TokenToBlob.Keys)
+            {
+                await _cache.RemoveAsync(TokenCacheKey(userId, token), cancellationToken);
+            }
+        }
+
+        await _cache.RemoveAsync(RoundCacheKey(userId, exerciseId, roundId), cancellationToken);
+    }
+
+    private async Task<RoundEnvelope?> LoadRoundAsync(
+        string userId,
+        int exerciseId,
+        string roundId,
+        CancellationToken cancellationToken)
+    {
+        var json = await _cache.GetStringAsync(RoundCacheKey(userId, exerciseId, roundId), cancellationToken);
+        if (string.IsNullOrEmpty(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonConvert.DeserializeObject<RoundEnvelope>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string RoundCacheKey(string userId, int exerciseId, string roundId)
+        => $"ExerciseRound:{userId}:{exerciseId}:{roundId}";
+
+    private static string TokenCacheKey(string userId, string token)
+        => $"AudioToken:{userId}:{token}";
+
+    private sealed record RoundEnvelope(
+        string RoundId,
+        string ExpectedAnswerJson,
+        Dictionary<string, string> TokenToBlob);
+
+    private sealed record TokenPointer(string RoundId, int ExerciseId);
+}

--- a/AcademiaAuditiva/Services/Audio/ExercisePlaybackPlanner.cs
+++ b/AcademiaAuditiva/Services/Audio/ExercisePlaybackPlanner.cs
@@ -1,0 +1,215 @@
+using AcademiaAuditiva.Interfaces;
+using AcademiaAuditiva.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AcademiaAuditiva.Services.Audio;
+
+/// <summary>
+/// Translates the existing untyped <see cref="MusicTheoryService.GenerateNoteForExercise"/>
+/// output into a list of <see cref="MixInput"/> playback plans without
+/// changing the <c>ExpectedAnswer</c> shape (the validators still consume
+/// the original JSON unchanged).
+///
+/// Produces:
+///   - 1 plan for GuessNote / GuessChords / GuessFunction / GuessQuality /
+///     GuessInterval / GuessFullInterval
+///   - 2 plans for GuessMissingNote (one per melody)
+///   - 0 plans for SolfegeMelody / IntervalMelodico (out of scope; the
+///     caller short-circuits by not invoking the mixer for those).
+/// </summary>
+public sealed class ExercisePlaybackPlanner
+{
+    // 120 BPM → one beat is half a second. Matches the Tone.js default
+    // tempo the front-end used when scheduling melodies, so playback
+    // duration stays the same end-to-end.
+    private const double BeatDurationSeconds = 0.5;
+
+    // Gap between sequential notes in interval exercises. Matches the
+    // 0.5s "delay" the JS sequencer used for GuessInterval/FullInterval.
+    private const double IntervalGapSeconds = 0.5;
+
+    // Chord/note clip length. Most piano sample blobs are ~3s sustained
+    // tones; clip them so the mix doesn't drag.
+    private const double NoteClipSeconds = 1.5;
+
+    /// <summary>
+    /// Returns the JSON to cache as <c>ExpectedAnswer</c> together with
+    /// the playback plans that need to be mixed and tokenized. An empty
+    /// list of plans means "no audio to issue" (the front will render
+    /// the question some other way — currently only sheet-music
+    /// exercises, which are out of scope for this anti-cheat work).
+    /// </summary>
+    public ExercisePlan Plan(Exercise exercise, Dictionary<string, string> filters)
+    {
+        ArgumentNullException.ThrowIfNull(exercise);
+        ArgumentNullException.ThrowIfNull(filters);
+
+        var raw = MusicTheoryService.GenerateNoteForExercise(exercise, filters);
+        var expectedJson = JsonConvert.SerializeObject(raw);
+        var token = JObject.Parse(expectedJson);
+
+        var plans = new List<IReadOnlyList<MixInput>>();
+        switch (exercise.Name)
+        {
+            case "GuessNote":
+                plans.Add(new[] { Note(token.Value<string>("note") ?? throw Bad("note")) });
+                break;
+
+            case "GuessChords":
+            case "GuessFunction":
+            case "GuessQuality":
+                plans.Add(NotesAtOnce(StringArray(token, "notes")));
+                break;
+
+            case "GuessInterval":
+            case "GuessFullInterval":
+                plans.Add(NotesInSequence(new[]
+                {
+                    token.Value<string>("note1") ?? throw Bad("note1"),
+                    token.Value<string>("note2") ?? throw Bad("note2"),
+                }));
+                break;
+
+            case "GuessMissingNote":
+                plans.Add(MelodyPlan(token["melody1"] as JArray ?? throw Bad("melody1")));
+                plans.Add(MelodyPlan(token["melody2"] as JArray ?? throw Bad("melody2")));
+                break;
+
+            case "SolfegeMelody":
+            case "IntervalMelodico":
+                // Sheet-music exercises — no audio token is issued.
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"ExercisePlaybackPlanner does not know how to plan '{exercise.Name}'.");
+        }
+
+        return new ExercisePlan(expectedJson, plans);
+    }
+
+    private static MixInput Note(string note, double startTime = 0.0) =>
+        new(NoteToBlob(note), startTime, NoteClipSeconds);
+
+    private static IReadOnlyList<MixInput> NotesAtOnce(IReadOnlyList<string> notes)
+    {
+        var plan = new MixInput[notes.Count];
+        for (var i = 0; i < notes.Count; i++)
+        {
+            plan[i] = Note(notes[i]);
+        }
+        return plan;
+    }
+
+    private static IReadOnlyList<MixInput> NotesInSequence(IReadOnlyList<string> notes)
+    {
+        var plan = new MixInput[notes.Count];
+        var t = 0.0;
+        for (var i = 0; i < notes.Count; i++)
+        {
+            plan[i] = Note(notes[i], t);
+            t += IntervalGapSeconds + NoteClipSeconds;
+        }
+        return plan;
+    }
+
+    private static IReadOnlyList<MixInput> MelodyPlan(JArray melody)
+    {
+        var plan = new List<MixInput>();
+        var t = 0.0;
+        foreach (var entry in melody)
+        {
+            var type = entry.Value<string>("type");
+            var note = entry.Value<string>("note");
+            var beats = entry.Value<double?>("duration") ?? 1.0;
+            var seconds = beats * BeatDurationSeconds;
+
+            if (type == "note" && !string.IsNullOrEmpty(note) && note != "rest")
+            {
+                plan.Add(new MixInput(NoteToBlob(note), t, seconds));
+            }
+            // rests advance the cursor without emitting an input.
+            t += seconds;
+        }
+        return plan;
+    }
+
+    private static IReadOnlyList<string> StringArray(JObject token, string field)
+    {
+        if (token[field] is not JArray arr)
+        {
+            throw Bad(field);
+        }
+        var notes = new string[arr.Count];
+        for (var i = 0; i < arr.Count; i++)
+        {
+            notes[i] = arr[i].Value<string>() ?? throw Bad(field);
+        }
+        return notes;
+    }
+
+    /// <summary>
+    /// Converts a music-theoretic note name (e.g. <c>C#4</c>, <c>Db5</c>)
+    /// to the blob filename in the <c>piano-audio</c> container. The
+    /// existing samples use <c>s</c> in place of <c>#</c> (e.g.
+    /// <c>Cs4.mp3</c>) and don't ship flat-named files — flats are
+    /// rewritten to their enharmonic sharp.
+    /// </summary>
+    private static string NoteToBlob(string note)
+    {
+        if (string.IsNullOrWhiteSpace(note))
+        {
+            throw new ArgumentException("Note name must not be empty.", nameof(note));
+        }
+
+        // Normalize flats to sharps — only sharp samples exist.
+        var normalized = note switch
+        {
+            _ when note.Contains('b') => FlatToSharp(note),
+            _ => note,
+        };
+        return normalized.Replace("#", "s") + ".mp3";
+    }
+
+    private static string FlatToSharp(string note)
+    {
+        // E.g. Db4 → C#4, Gb4 → F#4. Keep this small; complete tables
+        // already exist in MusicTheoryService for actual music theory.
+        var letter = note[0].ToString();
+        var octave = note[^1];
+        var prevLetter = letter switch
+        {
+            "A" => "G",
+            "B" => "A",
+            "C" => "B",
+            "D" => "C",
+            "E" => "D",
+            "F" => "E",
+            "G" => "F",
+            _ => letter,
+        };
+        // Cb / Fb don't exist as enharmonic sharps — fall through.
+        if (letter is "C" or "F")
+        {
+            return prevLetter + octave;
+        }
+        return prevLetter + "#" + octave;
+    }
+
+    private static InvalidOperationException Bad(string field) =>
+        new($"Generated exercise data is missing field '{field}'.");
+}
+
+/// <summary>
+/// Result of <see cref="ExercisePlaybackPlanner.Plan"/>.
+/// </summary>
+/// <param name="ExpectedAnswerJson">JSON to cache and feed to validators (unchanged shape).</param>
+/// <param name="PlaybackPlans">
+/// Mixer plans, in playback order. Empty list means "no audio token to
+/// issue" (sheet-music exercises). Most exercises produce one plan;
+/// GuessMissingNote produces two (melody1, melody2).
+/// </param>
+public sealed record ExercisePlan(
+    string ExpectedAnswerJson,
+    IReadOnlyList<IReadOnlyList<MixInput>> PlaybackPlans);

--- a/AcademiaAuditiva/Views/Shared/_Layout.cshtml
+++ b/AcademiaAuditiva/Views/Shared/_Layout.cshtml
@@ -188,7 +188,7 @@
     <script src="/js/dist/essentia.js-model.js?v=1.0.2"></script>
     <script src="/js/dist/essentia.js-plot.js?v=1.0.2"></script>
     <script src="/js/dist/essentia-wasm.web.js?v=1.0.2"></script>
-    <script src="/js/core/audio-engine.js?v=1.0.2"></script>
+    <script src="/js/core/audio-engine.js?v=1.0.4"></script>
     <script src="/js/games/game-engine.js?v=1.0.2"></script>
     <script src="/js/main/academia-auditiva.js?v=1.0.2"></script>
     <script src="/js/AcademiaAuditiva.Filters.js?v=1.0.2"></script>

--- a/AcademiaAuditiva/wwwroot/js/Exercises/GuessChords.js
+++ b/AcademiaAuditiva/wwwroot/js/Exercises/GuessChords.js
@@ -1,23 +1,17 @@
 document.addEventListener("DOMContentLoaded", () => {
-    //Iniciate Audio
     AcademiaAuditiva.init();
     AudioEngine.setupWaveform();
 
-    //Iniciate Variables
-    const exerciseIdInput = document.getElementById("exerciseId");
-    const exerciseId = exerciseIdInput ? exerciseIdInput.value : null;
-    const rangeSelect = document.querySelector('[name="Range"]');
-    const selectedRange = rangeSelect ? rangeSelect.value : "C3-C5";
+    const exerciseId = document.getElementById("exerciseId")?.value;
     const chordTypeSelect = document.getElementById("chordType");
     let chordType = chordTypeSelect ? chordTypeSelect.value : "major";
 
-    let randomRoot = "";
-    let randomQuality = "";
+    let playToken = null;
+    let roundId = null;
     let userRoot = "";
     let userQuality = "major";
     const exerciseStartTime = Date.now();
 
-    //Iniciate Click Events
     const rootButtons = document.querySelectorAll(".guessAnswer");
     rootButtons.forEach(btn => {
         btn.addEventListener("click", () => {
@@ -37,8 +31,6 @@ document.addEventListener("DOMContentLoaded", () => {
         btn.style.display = "none";
     });
 
-
-    //Inciate Play and Replay Events
     const playBtn = document.getElementById("Play");
     if (playBtn) {
         playBtn.addEventListener("click", () => {
@@ -49,25 +41,22 @@ document.addEventListener("DOMContentLoaded", () => {
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                     exerciseId: exerciseId,
-                    filters: {
-					    chordType: chordType
-                    }
+                    filters: { chordType: chordType }
                 })
             })
             .then(resp => resp.json())
             .then(data => {
-                window.currentChordNotes = data.notes;
-                randomRoot = data.root;
-                randomQuality = data.quality;
-                AudioEngine.playChord(data.notes, 1);
-            });            
+                playToken = data.playToken;
+                roundId = data.roundId;
+                if (playToken) AudioEngine.playToken(playToken);
+            });
         });
     }
 
     const replayBtn = document.getElementById("Replay");
     if (replayBtn) {
         replayBtn.addEventListener("click", () => {
-            if (!randomRoot || !randomQuality) {
+            if (!playToken) {
                 Swal.fire({
                     icon: "warning",
                     title: "No chord loaded",
@@ -75,17 +64,15 @@ document.addEventListener("DOMContentLoaded", () => {
                 });
                 return;
             }
-            AudioEngine.playChord(window.currentChordNotes, 1);
+            AudioEngine.playToken(playToken);
         });
     }
 
-
-    //Inciate Validate Event
     const validateBtn = document.getElementById("validateGuess");
     if (validateBtn) {
         validateBtn.addEventListener("click", () => {
-            if(chordType!= "major" && chordType!="minor"){
-                if (!userRoot || !userQuality || !randomRoot || !randomQuality) {
+            if (chordType != "major" && chordType != "minor") {
+                if (!userRoot || !userQuality || !roundId) {
                     Swal.fire({
                         icon: "warning",
                         title: "Missing data",
@@ -99,6 +86,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                     ExerciseId: exerciseId,
+                    RoundId: roundId,
                     UserGuess: userRoot + "|" + userQuality,
                     TimeSpentSeconds: Math.floor((Date.now() - exerciseStartTime) / 1000)
                 })
@@ -116,45 +104,36 @@ document.addEventListener("DOMContentLoaded", () => {
                     if (errorCountEl) {
                         errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
                     }
-                    Swal.fire("Wrong!", `The correct answer was ${data.answer.replace("|", " " )}.`, "error");
+                    Swal.fire("Wrong!", `The correct answer was ${(data.answer || "").replace("|", " ")}.`, "error");
                 }
-            
+
                 userRoot = "";
-                randomRoot = "";
-                randomQuality = "";
+                playToken = null;
+                roundId = null;
                 rootButtons.forEach(b => b.classList.remove("selected"));
                 qualityButtons.forEach(b => b.classList.remove("selected"));
-                if (chordType != "major" && chordType != "minor") { userQuality = "";}
-            });            
+                if (chordType != "major" && chordType != "minor") { userQuality = ""; }
+            });
         });
     }
 
-    //Inciate Filter Events
     if (chordTypeSelect) {
         chordTypeSelect.addEventListener("change", () => {
             const selectedType = chordTypeSelect.value;
-
             chordType = "";
-            qualityButtons.forEach(btn => {
-                btn.classList.remove("selected");
-            });
+            qualityButtons.forEach(btn => btn.classList.remove("selected"));
 
             switch (selectedType) {
                 case "major":
-                    qualityButtons.forEach(btn => {
-                        btn.style.display = "none";
-                    });
+                    qualityButtons.forEach(btn => btn.style.display = "none");
                     chordType = selectedType;
                     userQuality = selectedType;
                     break;
                 case "minor":
-                    qualityButtons.forEach(btn => {
-                        btn.style.display = "none";
-                    });
+                    qualityButtons.forEach(btn => btn.style.display = "none");
                     chordType = selectedType;
                     userQuality = selectedType;
                     break;
-
                 case "both":
                     qualityButtons.forEach(btn => {
                         const val = btn.value;
@@ -162,12 +141,9 @@ document.addEventListener("DOMContentLoaded", () => {
                     });
                     chordType = selectedType;
                     break;
-
                 case "all":
                 default:
-                    qualityButtons.forEach(btn => {
-                        btn.style.display = "inline-block";
-                    });
+                    qualityButtons.forEach(btn => btn.style.display = "inline-block");
                     break;
             }
         });

--- a/AcademiaAuditiva/wwwroot/js/Exercises/GuessFullInterval.js
+++ b/AcademiaAuditiva/wwwroot/js/Exercises/GuessFullInterval.js
@@ -1,21 +1,18 @@
 document.addEventListener("DOMContentLoaded", () => {
-  //Iniciate Audio
   AcademiaAuditiva.init();
   AudioEngine.setupWaveform();
 
   const loc = document.getElementById("localizer").dataset;
-  //Iniciate Variables
+
+  let playToken = null;
+  let roundId = null;
   let selectedGuess = "";
-  let note1 = "";
-  let note2 = "";
   let exerciseStartTime = Date.now();
 
   const exerciseId = document.getElementById("exerciseId")?.value;
-
   const keySelect = document.getElementById("keySelect");
   const directionSelect = document.getElementById("intervalDirection");
 
-  //Iniciate Click Events
   const guessButtons = document.querySelectorAll(".guessAnswer");
   guessButtons.forEach((button) => {
     button.addEventListener("click", (e) => {
@@ -25,7 +22,6 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  //Inciate Play and Replay Events
   const playBtn = document.getElementById("Play");
   if (playBtn) {
     playBtn.addEventListener("click", () => {
@@ -37,69 +33,43 @@ document.addEventListener("DOMContentLoaded", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           exerciseId: exerciseId,
-          filters: {
-            keySelect: key,
-            intervalDirection: direction,
-          },
+          filters: { keySelect: key, intervalDirection: direction },
         }),
       })
         .then((resp) => resp.json())
         .then((data) => {
-          note1 = data.note1;
-          note2 = data.note2;
-
-          if (note1 && note2) {
-            AudioEngine.playSequence([note1, note2], 0.6);
-          }
+          playToken = data.playToken;
+          roundId = data.roundId;
+          if (playToken) AudioEngine.playToken(playToken);
         })
-        .catch((err) => {
-          console.error("Erro ao gerar intervalo completo:", err);
-        });
+        .catch((err) => console.error("Erro ao gerar intervalo completo:", err));
     });
   }
 
   const replayBtn = document.getElementById("Replay");
   if (replayBtn) {
     replayBtn.addEventListener("click", () => {
-      if (!note1 || !note2) {
-        Swal.fire({
-          icon: "warning",
-          title: loc.incompleteTitle,
-          text: loc.incompleteText,
-        });
+      if (!playToken) {
+        Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
         return;
       }
-      AudioEngine.playSequence([note1, note2], 0.4);
+      AudioEngine.playToken(playToken);
     });
   }
 
+  // See GuessInterval.js: the per-note replay buttons are hidden so
+  // the page can no longer leak note identities through repeated
+  // single-note playback.
   const n1Btn = document.getElementById("Note1");
-  if (n1Btn) {
-    n1Btn.addEventListener("click", () => {
-      if (note1) AudioEngine.playNote(note1, 1);
-    });
-  }
-
+  if (n1Btn) n1Btn.style.display = "none";
   const n2Btn = document.getElementById("Note2");
-  if (n2Btn) {
-    n2Btn.addEventListener("click", () => {
-      if (note2) AudioEngine.playNote(note2, 1);
-    });
-  }
+  if (n2Btn) n2Btn.style.display = "none";
 
-  //Inciate Validate Event
   const validateBtn = document.getElementById("validateGuess");
   if (validateBtn) {
     validateBtn.addEventListener("click", () => {
-      const correctCountEl = document.getElementById("correctCount");
-      const errorCountEl = document.getElementById("errorCount");
-
       if (!selectedGuess) {
-        Swal.fire({
-          icon: "warning",
-          title: loc.incompleteTitle,
-          text: loc.incompleteText,
-        });
+        Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
         return;
       }
 
@@ -108,32 +78,26 @@ document.addEventListener("DOMContentLoaded", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           exerciseId: exerciseId,
+          roundId: roundId,
           userGuess: selectedGuess,
           timeSpentSeconds: Math.floor((Date.now() - exerciseStartTime) / 1000),
         }),
       })
         .then((resp) => resp.json())
         .then((data) => {
-			const correctCountEl = document.getElementById("correctCount");
-			const errorCountEl = document.getElementById("errorCount");
-			if (data.isCorrect) {
-			  if (correctCountEl) {
-				correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
-			  }
-			  Swal.fire("Correct!", "You got it right!", "success");
-			} else {
-			  if (errorCountEl) {
-				errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
-			  }
-			  Swal.fire(
-				"Wrong!", `The correct answer was ${data.answer}.`, "error"
-			  );
-			}
+          const correctCountEl = document.getElementById("correctCount");
+          const errorCountEl = document.getElementById("errorCount");
+          if (data.isCorrect) {
+            if (correctCountEl) correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
+            Swal.fire("Correct!", "You got it right!", "success");
+          } else {
+            if (errorCountEl) errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
+            Swal.fire("Wrong!", `The correct answer was ${data.answer}.`, "error");
+          }
 
-          // Reset
           selectedGuess = "";
-          note1 = "";
-          note2 = "";
+          playToken = null;
+          roundId = null;
           guessButtons.forEach((btn) => btn.classList.remove("selected"));
         });
     });

--- a/AcademiaAuditiva/wwwroot/js/Exercises/GuessFunction.js
+++ b/AcademiaAuditiva/wwwroot/js/Exercises/GuessFunction.js
@@ -1,19 +1,17 @@
 document.addEventListener("DOMContentLoaded", () => {
-  //Iniciate Audio
   AcademiaAuditiva.init();
   AudioEngine.setupWaveform();
 
   const loc = document.getElementById("localizer").dataset;
-  //Iniciate Variables
+  let playToken = null;
+  let roundId = null;
   let selectedGuess = "";
-  let chordNotes = [];
   let exerciseStartTime = Date.now();
 
   const exerciseId = document.getElementById("exerciseId")?.value;
   const keySelect = document.getElementById("keySelect");
   const scaleTypeSelect = document.getElementById("scaleTypeSelect");
 
-  //Iniciate Click Events
   const guessButtons = document.querySelectorAll(".guessAnswer");
   guessButtons.forEach((button) => {
     button.addEventListener("click", (e) => {
@@ -23,7 +21,6 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  //Inciate Play and Replay Events
   const playBtn = document.getElementById("Play");
   if (playBtn) {
     playBtn.addEventListener("click", () => {
@@ -37,16 +34,14 @@ document.addEventListener("DOMContentLoaded", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           exerciseId: exerciseId,
-          filters: {
-            keySelect: key,
-            scaleTypeSelect: scaleType,
-          },
+          filters: { keySelect: key, scaleTypeSelect: scaleType },
         }),
       })
         .then((resp) => resp.json())
         .then((data) => {
-          chordNotes = data.notes;
-          AudioEngine.playChord(chordNotes, 1);
+          playToken = data.playToken;
+          roundId = data.roundId;
+          if (playToken) AudioEngine.playToken(playToken);
         });
     });
   }
@@ -54,28 +49,19 @@ document.addEventListener("DOMContentLoaded", () => {
   const replayBtn = document.getElementById("Replay");
   if (replayBtn) {
     replayBtn.addEventListener("click", () => {
-      if (!chordNotes || chordNotes.length === 0) {
-        Swal.fire({
-          icon: "warning",
-          title: loc.incompleteTitle,
-          text: loc.incompleteText,
-        });
+      if (!playToken) {
+        Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
         return;
       }
-      AudioEngine.playChord(chordNotes, 1);
+      AudioEngine.playToken(playToken);
     });
   }
 
-  //Inciate Validate Event
   const validateBtn = document.getElementById("validateGuess");
   if (validateBtn) {
     validateBtn.addEventListener("click", () => {
       if (!selectedGuess) {
-        Swal.fire({
-          icon: "warning",
-          title: loc.incompleteTitle,
-          text: loc.incompleteText,
-        });
+        Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
         return;
       }
 
@@ -84,6 +70,7 @@ document.addEventListener("DOMContentLoaded", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           exerciseId: exerciseId,
+          roundId: roundId,
           userGuess: selectedGuess,
           timeSpentSeconds: Math.floor((Date.now() - exerciseStartTime) / 1000),
         }),
@@ -93,52 +80,36 @@ document.addEventListener("DOMContentLoaded", () => {
           const correctCountEl = document.getElementById("correctCount");
           const errorCountEl = document.getElementById("errorCount");
           if (data.isCorrect) {
-            if (correctCountEl) {
-              correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
-            }
+            if (correctCountEl) correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
             Swal.fire("Correct!", "You got it right!", "success");
           } else {
-            if (errorCountEl) {
-              errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
-            }
-            Swal.fire(
-              "Wrong!",
-              `The correct answer was ${data.answer.replace("|", " ")}.`,
-              "error"
-            );
+            if (errorCountEl) errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
+            Swal.fire("Wrong!", `The correct answer was ${(data.answer || "").replace("|", " ")}.`, "error");
           }
 
-          // Reset
           selectedGuess = "";
-          chordNotes = [];
+          playToken = null;
+          roundId = null;
           guessButtons.forEach((btn) => btn.classList.remove("selected"));
         });
     });
   }
 
-  //Inciate Filter Events
   function toggleFunctionButtons(scaleType) {
     const majorFunctions = ["I", "ii", "iii", "IV", "V", "vi", "VII°"];
     const minorFunctions = ["i", "II°", "III", "iv", "v", "VI", "VII"];
-
     const guessButtons = document.querySelectorAll(".guessAnswer");
 
     guessButtons.forEach((btn) => {
       const label = btn.innerText.trim();
       if (scaleType === "major") {
-        btn.style.display = majorFunctions.includes(label)
-          ? "inline-block"
-          : "none";
+        btn.style.display = majorFunctions.includes(label) ? "inline-block" : "none";
       } else if (scaleType === "minor") {
-        btn.style.display = minorFunctions.includes(label)
-          ? "inline-block"
-          : "none";
+        btn.style.display = minorFunctions.includes(label) ? "inline-block" : "none";
       }
     });
   }
 
-  scaleTypeSelect?.addEventListener("change", () => {
-    toggleFunctionButtons(scaleTypeSelect.value);
-  });
+  scaleTypeSelect?.addEventListener("change", () => toggleFunctionButtons(scaleTypeSelect.value));
   toggleFunctionButtons(scaleTypeSelect?.value || "major");
 });

--- a/AcademiaAuditiva/wwwroot/js/Exercises/GuessInterval.js
+++ b/AcademiaAuditiva/wwwroot/js/Exercises/GuessInterval.js
@@ -1,20 +1,16 @@
 document.addEventListener("DOMContentLoaded", () => {
-  //Iniciate Audio
   AcademiaAuditiva.init();
   AudioEngine.setupWaveform();
 
-  //Iniciate Variables
   const loc = document.getElementById("localizer").dataset;
 
-  let note1 = null;
-  let note2 = null;
+  let playToken = null;
+  let roundId = null;
   let selectedGuess = "";
   let exerciseStartTime = Date.now();
 
-  const exerciseIdInput = document.getElementById("exerciseId");
-  const exerciseId = exerciseIdInput ? exerciseIdInput.value : null;
+  const exerciseId = document.getElementById("exerciseId")?.value;
 
-  //Iniciate Click Events
   const guessButtons = document.querySelectorAll(".guessAnswer");
   guessButtons.forEach((button) => {
     button.addEventListener("click", (e) => {
@@ -24,7 +20,6 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  //Inciate Play and Replay Events
   const playBtn = document.getElementById("Play");
   if (playBtn) {
     playBtn.addEventListener("click", () => {
@@ -36,73 +31,44 @@ document.addEventListener("DOMContentLoaded", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           exerciseId: exerciseId,
-          filters: {
-            keySelect: tonic,
-            scaleTypeSelect: scaleType,
-          },
+          filters: { keySelect: tonic, scaleTypeSelect: scaleType },
         }),
       })
         .then((resp) => resp.json())
         .then((data) => {
-          note1 = data.note1;
-          note2 = data.note2;
-
-          if (note1 && note2) {
-            AudioEngine.playSequence([note1, note2], 0.6);
-          }
+          playToken = data.playToken;
+          roundId = data.roundId;
+          if (playToken) AudioEngine.playToken(playToken);
         })
-        .catch((err) => {
-          console.error("Erro ao preparar intervalo:", err);
-        });
+        .catch((err) => console.error("Erro ao preparar intervalo:", err));
     });
   }
 
   const replayBtn = document.getElementById("Replay");
   if (replayBtn) {
     replayBtn.addEventListener("click", () => {
-      if (!note1 || !note2) {
-        Swal.fire({
-          icon: "warning",
-          title: loc.incompleteTitle,
-          text: loc.incompleteText,
-        });
+      if (!playToken) {
+        Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
         return;
       }
-      AudioEngine.playSequence([note1, note2], 0.4);
+      AudioEngine.playToken(playToken);
     });
   }
 
+  // The legacy "play just note 1 / note 2" buttons relied on the
+  // front-end knowing both pitches in clear text. With token-based
+  // playback, the round only ships one mixed clip — we hide those
+  // buttons so the markup stays as-is even if they happen to render.
   const n1Btn = document.getElementById("Note1");
-  if (n1Btn) {
-    n1Btn.addEventListener("click", () => {
-      if (note1) {
-        AudioEngine.playNote(note1, 1);
-      }
-    });
-  }
-
+  if (n1Btn) n1Btn.style.display = "none";
   const n2Btn = document.getElementById("Note2");
-  if (n2Btn) {
-    n2Btn.addEventListener("click", () => {
-      if (note2) {
-        AudioEngine.playNote(note2, 1);
-      }
-    });
-  }
+  if (n2Btn) n2Btn.style.display = "none";
 
-  //Inciate Validate Event
   const validateBtn = document.getElementById("validateGuess");
   if (validateBtn) {
     validateBtn.addEventListener("click", () => {
-      const correctCountEl = document.getElementById("correctCount");
-      const errorCountEl = document.getElementById("errorCount");
-
       if (!selectedGuess) {
-        Swal.fire({
-          icon: "warning",
-          title: loc.incompleteTitle,
-          text: loc.incompleteText,
-        });
+        Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
         return;
       }
 
@@ -111,30 +77,26 @@ document.addEventListener("DOMContentLoaded", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           exerciseId: exerciseId,
+          roundId: roundId,
           userGuess: selectedGuess,
           timeSpentSeconds: Math.floor((Date.now() - exerciseStartTime) / 1000),
         }),
       })
         .then((resp) => resp.json())
         .then((data) => {
-			const correctCountEl = document.getElementById("correctCount");
-			const errorCountEl = document.getElementById("errorCount");
-			if (data.isCorrect) {
-				if (correctCountEl) {
-					correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
-				}
-				Swal.fire("Correct!", "You got the interval right!", "success");
-			} else {
-				if (errorCountEl) {
-					errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
-				}
-				Swal.fire("Wrong!", `The correct interval was ${data.answer}.`, "error");
-			}
+          const correctCountEl = document.getElementById("correctCount");
+          const errorCountEl = document.getElementById("errorCount");
+          if (data.isCorrect) {
+            if (correctCountEl) correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
+            Swal.fire("Correct!", "You got the interval right!", "success");
+          } else {
+            if (errorCountEl) errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
+            Swal.fire("Wrong!", `The correct interval was ${data.answer}.`, "error");
+          }
 
-          // Reset
           selectedGuess = "";
-          note1 = null;
-          note2 = null;
+          playToken = null;
+          roundId = null;
           guessButtons.forEach((btn) => btn.classList.remove("selected"));
         });
     });

--- a/AcademiaAuditiva/wwwroot/js/Exercises/GuessMissingNote.js
+++ b/AcademiaAuditiva/wwwroot/js/Exercises/GuessMissingNote.js
@@ -1,19 +1,20 @@
 document.addEventListener("DOMContentLoaded", () => {
-  //Iniciate Audio
   AcademiaAuditiva.init();
   AudioEngine.setupWaveform();
 
   const loc = document.getElementById("localizer").dataset;
-  //Iniciate Variables
-  let melody1 = [];
-  let melody2 = [];
+
+  // Two tokens — one per melody. The user MUST listen to both clips
+  // and decide same/different by ear; the front cannot infer the
+  // answer from the response (no melody arrays leak any more).
+  let melody1Token = null;
+  let melody2Token = null;
+  let roundId = null;
   let selectedGuess = "";
   let exerciseStartTime = Date.now();
 
-  const exerciseIdInput = document.getElementById("exerciseId");
-  const exerciseId = exerciseIdInput ? exerciseIdInput.value : null;
+  const exerciseId = document.getElementById("exerciseId")?.value;
 
-  //Iniciate Click Events
   const guessButtons = document.querySelectorAll(".guessAnswer");
   guessButtons.forEach((button) => {
     button.addEventListener("click", (e) => {
@@ -22,6 +23,13 @@ document.addEventListener("DOMContentLoaded", () => {
       selectedGuess = e.target.value;
     });
   });
+
+  async function playBoth(gapSeconds) {
+    if (!melody1Token || !melody2Token) return;
+    await AudioEngine.playToken(melody1Token);
+    await new Promise((r) => setTimeout(r, gapSeconds * 1000));
+    await AudioEngine.playToken(melody2Token);
+  }
 
   const playBtn = document.getElementById("Play");
   if (playBtn) {
@@ -33,83 +41,61 @@ document.addEventListener("DOMContentLoaded", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           exerciseId: exerciseId,
-          filters: {
-            melodyLength: length,
-          },
+          filters: { melodyLength: length },
         }),
       })
         .then((resp) => resp.json())
         .then((data) => {
-          melody1 = data.melody1;
-          melody2 = data.melody2;
-          AcademiaAuditiva.audio.playMelodyWithRhythm(melody1);
-          const totalTime = melody1.reduce((sum, n) => sum + n.duration, 0);
-
-          setTimeout(() => {
-            AcademiaAuditiva.audio.playMelodyWithRhythm(melody2);
-          }, (totalTime + 1) * 1000);
+          melody1Token = data.melody1Token;
+          melody2Token = data.melody2Token;
+          roundId = data.roundId;
+          // 1s gap between the two melodies, matching the legacy UX.
+          playBoth(1.0);
         })
-        .catch((err) => {
-          console.error("Erro ao gerar melodias:", err);
-        });
+        .catch((err) => console.error("Erro ao gerar melodias:", err));
     });
   }
 
   const replayBtn = document.getElementById("Replay");
   if (replayBtn) {
     replayBtn.addEventListener("click", () => {
-      if (!melody1.length || !melody2.length) {
-        Swal.fire({
-          icon: "warning",
-          title: loc.incompleteTitle,
-          text: loc.incompleteText,
-        });
+      if (!melody1Token || !melody2Token) {
+        Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
         return;
       }
-      AudioEngine.playSequence(melody1, 0.35, () => {
-        setTimeout(() => AudioEngine.playSequence(melody2, 0.35), 600);
-      });
+      playBoth(0.6);
     });
   }
 
   const m1Btn = document.getElementById("Melody1");
   if (m1Btn) {
     m1Btn.addEventListener("click", () => {
-      if (melody1.length) AudioEngine.playSequence(melody1, 0.35);
+      if (melody1Token) AudioEngine.playToken(melody1Token);
     });
   }
 
   const m2Btn = document.getElementById("Melody2");
   if (m2Btn) {
     m2Btn.addEventListener("click", () => {
-      if (melody2.length) AudioEngine.playSequence(melody2, 0.35);
+      if (melody2Token) AudioEngine.playToken(melody2Token);
     });
   }
 
   const validateBtn = document.getElementById("validateGuess");
   if (validateBtn) {
     validateBtn.addEventListener("click", () => {
-      if (!selectedGuess || !melody1.length || !melody2.length) {
-        Swal.fire({
-          icon: "warning",
-          title: loc.incompleteTitle,
-          text: loc.incompleteText,
-        });
+      if (!selectedGuess || !roundId) {
+        Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
         return;
       }
-
-      const isEqual = JSON.stringify(melody1) === JSON.stringify(melody2);
-      const userIsCorrect =
-        (isEqual && selectedGuess === "same") ||
-        (!isEqual && selectedGuess === "diff");
 
       fetch("/Exercise/ValidateExercise", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           exerciseId: exerciseId,
+          roundId: roundId,
           userGuess: selectedGuess,
-          actualAnswer: isEqual ? "same" : "diff",
           timeSpentSeconds: Math.floor((Date.now() - exerciseStartTime) / 1000),
         }),
       })
@@ -118,24 +104,17 @@ document.addEventListener("DOMContentLoaded", () => {
           const correctCountEl = document.getElementById("correctCount");
           const errorCountEl = document.getElementById("errorCount");
           if (data.isCorrect) {
-            if (correctCountEl) {
-              correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
-            }
+            if (correctCountEl) correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
             Swal.fire("Correct!", "You got it right!", "success");
           } else {
-            if (errorCountEl) {
-              errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
-            }
-            Swal.fire(
-              "Wrong!",
-              `The correct answer was ${data.answer}.`,
-              "error"
-            );
+            if (errorCountEl) errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
+            Swal.fire("Wrong!", `The correct answer was ${data.answer}.`, "error");
           }
 
           selectedGuess = "";
-          melody1 = [];
-          melody2 = [];
+          melody1Token = null;
+          melody2Token = null;
+          roundId = null;
           guessButtons.forEach((btn) => btn.classList.remove("selected"));
         });
     });

--- a/AcademiaAuditiva/wwwroot/js/Exercises/GuessNote.js
+++ b/AcademiaAuditiva/wwwroot/js/Exercises/GuessNote.js
@@ -1,17 +1,17 @@
 document.addEventListener("DOMContentLoaded", () => {
-  //Iniciate Audio
   AcademiaAuditiva.init();
   AudioEngine.setupWaveform();
 
-  //Iniciate Variables
-  const exerciseIdInput = document.getElementById("exerciseId");
-  const exerciseId = exerciseIdInput ? exerciseIdInput.value : null;
+  const exerciseId = document.getElementById("exerciseId")?.value;
 
-  let randomNote = "";
+  // The front-end never learns the actual note. It only holds the
+  // token (to replay) and the roundId (to validate against the same
+  // round). Both come from RequestPlay; both are opaque GUIDs.
+  let playToken = null;
+  let roundId = null;
   let userGuessedNote = "";
   const exerciseStartTime = Date.now();
 
-  //Iniciate Click Events
   const guessButtons = document.querySelectorAll(".guessAnswer");
   guessButtons.forEach((button) => {
     button.addEventListener("click", () => {
@@ -21,7 +21,6 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  //Inciate Play and Replay Events
   const playButton = document.getElementById("Play");
   if (playButton) {
     playButton.addEventListener("click", () => {
@@ -29,14 +28,13 @@ document.addEventListener("DOMContentLoaded", () => {
       fetch("/Exercise/RequestPlay", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          exerciseId: exerciseId,
-        }),
+        body: JSON.stringify({ exerciseId: exerciseId }),
       })
         .then((resp) => resp.json())
         .then((data) => {
-          randomNote = data.note;
-          AudioEngine.playNote(randomNote, 1);
+          playToken = data.playToken;
+          roundId = data.roundId;
+          if (playToken) AudioEngine.playToken(playToken);
         });
     });
   }
@@ -44,7 +42,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const replayButton = document.getElementById("Replay");
   if (replayButton) {
     replayButton.addEventListener("click", () => {
-      if (!randomNote) {
+      if (!playToken) {
         Swal.fire({
           icon: "warning",
           title: "No note loaded",
@@ -52,15 +50,14 @@ document.addEventListener("DOMContentLoaded", () => {
         });
         return;
       }
-      AudioEngine.playNote(randomNote, 1);
+      AudioEngine.playToken(playToken);
     });
   }
 
-  //Inciate Validate Event
   const validateBtn = document.getElementById("validateGuess");
   if (validateBtn) {
     validateBtn.addEventListener("click", () => {
-      if (!userGuessedNote || !randomNote) {
+      if (!userGuessedNote || !roundId) {
         Swal.fire({
           icon: "warning",
           title: "Missing data",
@@ -73,6 +70,7 @@ document.addEventListener("DOMContentLoaded", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ExerciseId: exerciseId,
+          RoundId: roundId,
           userGuess: userGuessedNote,
           timeSpentSeconds: Math.floor((Date.now() - exerciseStartTime) / 1000),
         }),
@@ -92,14 +90,15 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             Swal.fire(
               "Wrong!",
-              `The correct note was ${data.answer
+              `The correct note was ${(data.answer || "")
                 .replace(/\d/g, "")
                 .toUpperCase()}.`,
               "error"
             );
           }
           userGuessedNote = "";
-          randomNote = "";
+          playToken = null;
+          roundId = null;
           guessButtons.forEach((btn) => btn.classList.remove("selected"));
         });
     });

--- a/AcademiaAuditiva/wwwroot/js/Exercises/GuessQuality.js
+++ b/AcademiaAuditiva/wwwroot/js/Exercises/GuessQuality.js
@@ -1,125 +1,110 @@
 document.addEventListener("DOMContentLoaded", () => {
-    //Iniciate Audio
-	AcademiaAuditiva.init();
-	AudioEngine.setupWaveform();
+    AcademiaAuditiva.init();
+    AudioEngine.setupWaveform();
 
-	const loc = document.getElementById("localizer").dataset;
-	//Iniciate Variables
-	let selectedGuess = "";
-	let chordNotes = [];
-	let exerciseStartTime = Date.now();
+    const loc = document.getElementById("localizer").dataset;
+    let playToken = null;
+    let roundId = null;
+    let selectedGuess = "";
+    let exerciseStartTime = Date.now();
 
-	const exerciseId = document.getElementById("exerciseId")?.value;
-	const chordGroupSelect = document.getElementById("chordGroup");
-	let chordGroup = chordGroupSelect?.value || "all";
+    const exerciseId = document.getElementById("exerciseId")?.value;
+    const chordGroupSelect = document.getElementById("chordGroup");
+    let chordGroup = chordGroupSelect?.value || "all";
 
-	//Iniciate Click Events
-	const guessButtons = document.querySelectorAll(".guessAnswer");
-	guessButtons.forEach(button => {
-		button.addEventListener("click", (e) => {
-			guessButtons.forEach(btn => btn.classList.remove("selected"));
-			e.target.classList.add("selected");
-			selectedGuess = e.target.value;
-		});
-	});
+    const guessButtons = document.querySelectorAll(".guessAnswer");
+    guessButtons.forEach(button => {
+        button.addEventListener("click", (e) => {
+            guessButtons.forEach(btn => btn.classList.remove("selected"));
+            e.target.classList.add("selected");
+            selectedGuess = e.target.value;
+        });
+    });
 
-	//Inciate Play and Replay Events
-	const playBtn = document.getElementById("Play");
-	if (playBtn) {
-		playBtn.addEventListener("click", () => {
-			chordGroup = chordGroupSelect?.value || "all";
+    const playBtn = document.getElementById("Play");
+    if (playBtn) {
+        playBtn.addEventListener("click", () => {
+            chordGroup = chordGroupSelect?.value || "all";
 
-			fetch("/Exercise/RequestPlay", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					exerciseId: exerciseId,
-					filters: { chordGroup: chordGroup }
-				})
-			})
-				.then(resp => resp.json())
-				.then(data => {
-					chordNotes = data.notes;
-					AudioEngine.playChord(chordNotes, 1);
-				});
-		});
-	}
+            fetch("/Exercise/RequestPlay", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    exerciseId: exerciseId,
+                    filters: { chordGroup: chordGroup }
+                })
+            })
+                .then(resp => resp.json())
+                .then(data => {
+                    playToken = data.playToken;
+                    roundId = data.roundId;
+                    if (playToken) AudioEngine.playToken(playToken);
+                });
+        });
+    }
 
-	const replayBtn = document.getElementById("Replay");
-	if (replayBtn) {
-		replayBtn.addEventListener("click", () => {
-			if (!chordNotes || chordNotes.length === 0) {
-				Swal.fire({
-					icon: "warning",
-					title: loc.incompleteTitle,
-					text: loc.incompleteText
-				});
-				return;
-			}
-			AudioEngine.playChord(chordNotes, 1);
-		});
-	}
+    const replayBtn = document.getElementById("Replay");
+    if (replayBtn) {
+        replayBtn.addEventListener("click", () => {
+            if (!playToken) {
+                Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
+                return;
+            }
+            AudioEngine.playToken(playToken);
+        });
+    }
 
-	//Inciate Validate Event
-	const validateBtn = document.getElementById("validateGuess");
-	if (validateBtn) {
-		validateBtn.addEventListener("click", () => {
-			if (!selectedGuess) {
-				Swal.fire({
-					icon: "warning",
-					title: loc.incompleteTitle,
-					text: loc.incompleteText
-				});
-				return;
-			}
+    const validateBtn = document.getElementById("validateGuess");
+    if (validateBtn) {
+        validateBtn.addEventListener("click", () => {
+            if (!selectedGuess) {
+                Swal.fire({ icon: "warning", title: loc.incompleteTitle, text: loc.incompleteText });
+                return;
+            }
 
-			fetch("/Exercise/ValidateExercise", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					exerciseId: exerciseId,
-					userGuess: selectedGuess,
-					timeSpentSeconds: Math.floor((Date.now() - exerciseStartTime) / 1000)
-				})
-			})
-				.then(resp => resp.json())
-				.then(data => {
-					const correctCountEl = document.getElementById("correctCount");
-					const errorCountEl = document.getElementById("errorCount");
-					if (data.isCorrect) {
-						if (correctCountEl) {
-							correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
-						}
-						Swal.fire("Correct!", "You got it right!", "success");
-					} else {
-						if (errorCountEl) {
-							errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
-						}
-						Swal.fire("Wrong!", `The correct answer was ${data.answer}.`, "error");
-					}
+            fetch("/Exercise/ValidateExercise", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    exerciseId: exerciseId,
+                    roundId: roundId,
+                    userGuess: selectedGuess,
+                    timeSpentSeconds: Math.floor((Date.now() - exerciseStartTime) / 1000)
+                })
+            })
+                .then(resp => resp.json())
+                .then(data => {
+                    const correctCountEl = document.getElementById("correctCount");
+                    const errorCountEl = document.getElementById("errorCount");
+                    if (data.isCorrect) {
+                        if (correctCountEl) correctCountEl.innerText = parseInt(correctCountEl.innerText) + 1;
+                        Swal.fire("Correct!", "You got it right!", "success");
+                    } else {
+                        if (errorCountEl) errorCountEl.innerText = parseInt(errorCountEl.innerText) + 1;
+                        Swal.fire("Wrong!", `The correct answer was ${data.answer}.`, "error");
+                    }
 
-					// Reset
-					selectedGuess = "";
-					chordNotes = [];
-					guessButtons.forEach((btn) => btn.classList.remove("selected"));
-				});
-		});
-	}
+                    selectedGuess = "";
+                    playToken = null;
+                    roundId = null;
+                    guessButtons.forEach((btn) => btn.classList.remove("selected"));
+                });
+        });
+    }
 
-	function updateVisibleButtons() {
-		const allowed = chordGroup === "both"
-			? ["major", "minor"]
-			: ["major", "major7", "minor", "minor7", "diminished", "diminished7", "augmented"];
-	
-		guessButtons.forEach(btn => {
-			const value = btn.value;
-			btn.style.display = allowed.includes(value) ? "inline-block" : "none";
-		});
-	}
-	
-	chordGroupSelect?.addEventListener("change", (e) => {
-		chordGroup = e.target.value;
-		updateVisibleButtons();
-	});
-	updateVisibleButtons();
+    function updateVisibleButtons() {
+        const allowed = chordGroup === "both"
+            ? ["major", "minor"]
+            : ["major", "major7", "minor", "minor7", "diminished", "diminished7", "augmented"];
+        guessButtons.forEach(btn => {
+            const value = btn.value;
+            btn.style.display = allowed.includes(value) ? "inline-block" : "none";
+        });
+    }
+
+    chordGroupSelect?.addEventListener("change", (e) => {
+        chordGroup = e.target.value;
+        updateVisibleButtons();
+    });
+    updateVisibleButtons();
 });

--- a/AcademiaAuditiva/wwwroot/js/core/audio-engine.js
+++ b/AcademiaAuditiva/wwwroot/js/core/audio-engine.js
@@ -1,74 +1,95 @@
-
+// Audio engine — token-based playback for the anti-cheat flow.
+//
+// The legacy build wired Tone.Sampler to a public `/audio/{note}.mp3`
+// endpoint, which leaked the question identity in DevTools. The new
+// flow keeps Tone.js on the page (so the waveform visualisation still
+// works), but every exercise plays a SINGLE pre-mixed clip addressed
+// only by an opaque round token. The browser never sees a note name.
+//
+// Public API:
+//   AudioEngine.playToken(token)  → Promise that resolves when the clip
+//                                   finishes playing
+//   AudioEngine.stop()            → interrupts the currently playing clip
+//   AudioEngine.preload(token)    → optional hint to fetch the buffer
+//                                   without playing yet
+//   AudioEngine.setupWaveform(id) → unchanged visual hook
 const AudioEngine = (() => {
-    let sampler = null;
+    // A round produces one or two tokens; both are short clips. Caching
+    // the decoded buffer by token lets Replay be instant without a
+    // second fetch (and the server already declines to cache server-side).
+    const bufferCache = new Map();
+    let currentSource = null;
+    let started = false;
 
-    function initSampler() {
-        sampler = new Tone.Sampler(generateNoteUrls(), {
-            release: 1,
-            baseUrl: "https://stacademiaauditiva.blob.core.windows.net/piano-audio/",
-        }).toDestination();
-    }
-
-    function generateNoteUrls() {
-        const notes = ["C", "D", "E", "F", "G", "A", "B"];
-        const octaves = [1, 2, 3, 4, 5, 6, 7];
-        const noteUrls = {};
-
-        for (const octave of octaves) {
-            for (const note of notes) {
-                const noteName = note + octave;
-                noteUrls[noteName] = noteName + ".mp3";
-
-                // Sustenidos
-                if (note !== "E" && note !== "B") {
-                    const sharpNoteName = note + "#" + octave;
-                    noteUrls[sharpNoteName] = note.replace("#", "s") + octave + ".mp3";
-                }
+    async function ensureContext() {
+        if (!started) {
+            try {
+                await Tone.start();
+            } catch (err) {
+                // Tone.start throws when called outside a user gesture;
+                // first click on Play always provides one, but defensive
+                // logging helps diagnose if a future flow regresses.
+                console.warn("Tone.start() failed:", err);
             }
+            started = true;
         }
-        return noteUrls;
     }
 
-    function playNote(note, duration = "0.5") {
-        if (sampler) sampler.triggerAttackRelease(note, duration);
-    }
-
-    function playSequence(notes, duration = 0.5, delay = 0.6) {
-        if (!sampler) return;
-        let time = 0;
-        for (let note of notes) {
-            Tone.Transport.scheduleOnce(() => {
-                playNote(note, duration);
-            }, `+${time}`);
-            time += delay;
+    async function loadBuffer(token) {
+        if (bufferCache.has(token)) {
+            return bufferCache.get(token);
         }
-        Tone.Transport.start();
-    }
-
-    function playChord(notes, duration = 1) {
-        if (!sampler || !notes || notes.length === 0) return;
-        notes.forEach(note => {
-            sampler.triggerAttackRelease(note, duration);
+        const resp = await fetch(`/audio/token/${encodeURIComponent(token)}`, {
+            credentials: "same-origin",
+            cache: "no-store"
         });
-    }    
-
-    function playMelodyWithRhythm(melody) {
-        if (!sampler || !melody || melody.length === 0) return;
-    
-        let time = 0;
-        for (let item of melody) {
-            if (item.type === "note") {
-                Tone.Transport.scheduleOnce(() => {
-                    playNote(item.note, item.duration);
-                }, `+${time}`);
-            }
-            time += item.duration;
+        if (!resp.ok) {
+            throw new Error(`Audio fetch failed: ${resp.status}`);
         }
-    
-        Tone.Transport.start();
+        const arrayBuffer = await resp.arrayBuffer();
+        const audioBuffer = await Tone.context.decodeAudioData(arrayBuffer);
+        bufferCache.set(token, audioBuffer);
+        return audioBuffer;
     }
 
-    // === WAVEFORM VISUAL ===
+    async function preload(token) {
+        if (!token) return;
+        try { await loadBuffer(token); } catch (err) { console.warn("preload failed", err); }
+    }
+
+    function stop() {
+        if (currentSource) {
+            try { currentSource.stop(); } catch { /* already stopped */ }
+            currentSource = null;
+        }
+    }
+
+    async function playToken(token) {
+        if (!token) return;
+        await ensureContext();
+        const buffer = await loadBuffer(token);
+
+        stop();
+
+        // Use a raw BufferSource — Tone.Player would also work, but
+        // BufferSource is the lowest-friction primitive for "play this
+        // exact buffer once" and keeps the destination wired through
+        // Tone.Destination so setupWaveform's analyser still observes it.
+        const source = Tone.context.createBufferSource();
+        source.buffer = buffer;
+        source.connect(Tone.Destination.input ?? Tone.Destination);
+        currentSource = source;
+
+        return new Promise((resolve) => {
+            source.onended = () => {
+                if (currentSource === source) currentSource = null;
+                resolve();
+            };
+            source.start();
+        });
+    }
+
+    // === WAVEFORM VISUAL === (unchanged behaviour)
     let waveformCanvas;
     let analyser;
     let audioContext = Tone.context;
@@ -130,14 +151,72 @@ const AudioEngine = (() => {
         draw();
     }
 
-
     return {
-        initSampler,
-        generateNoteUrls,
-        playNote,
-        playSequence,
-        playChord,
-        playMelodyWithRhythm,
-        setupWaveform
+        playToken,
+        preload,
+        stop,
+        setupWaveform,
+        // === Legacy API ===
+        // Used only by the sheet-music exercises (IntervalMelodico,
+        // and SolfegeMelody if it grows playback) where the note name
+        // is already visible to the learner. Backed by Tone.Sampler
+        // pulling from the authenticated /audio/{name} endpoint.
+        playNote: legacyPlayNote,
+        playSequence: legacyPlaySequence,
+        playChord: legacyPlayChord,
+        playMelodyWithRhythm: legacyPlayMelodyWithRhythm
     };
 })();
+
+// === Legacy Sampler-based API (sheet-music exercises only) ===
+// Kept on AudioEngine as a separate path so the new token flow stays
+// the only audio code path for the seven anti-cheat exercises.
+let __legacySampler = null;
+function __initLegacySampler() {
+    if (__legacySampler) return __legacySampler;
+    const baseUrl = "/audio/";
+    const noteUrls = {};
+    const notes = ["C", "D", "E", "F", "G", "A", "B"];
+    const octaves = [1, 2, 3, 4, 5, 6, 7];
+    for (const oct of octaves) {
+        for (const n of notes) {
+            const name = n + oct;
+            noteUrls[name] = name + ".mp3";
+            if (n !== "E" && n !== "B") {
+                noteUrls[n + "#" + oct] = n + "s" + oct + ".mp3";
+            }
+        }
+    }
+    __legacySampler = new Tone.Sampler(noteUrls, { release: 1, baseUrl }).toDestination();
+    return __legacySampler;
+}
+function legacyPlayNote(note, duration = "0.5") {
+    const s = __initLegacySampler();
+    s.triggerAttackRelease(note, duration);
+}
+function legacyPlaySequence(notes, duration = 0.5, delay = 0.6) {
+    const s = __initLegacySampler();
+    let t = 0;
+    for (const note of notes) {
+        Tone.Transport.scheduleOnce(() => s.triggerAttackRelease(note, duration), `+${t}`);
+        t += delay;
+    }
+    Tone.Transport.start();
+}
+function legacyPlayChord(notes, duration = 1) {
+    if (!notes || notes.length === 0) return;
+    const s = __initLegacySampler();
+    notes.forEach(note => s.triggerAttackRelease(note, duration));
+}
+function legacyPlayMelodyWithRhythm(melody) {
+    if (!melody || melody.length === 0) return;
+    const s = __initLegacySampler();
+    let t = 0;
+    for (const item of melody) {
+        if (item.type === "note") {
+            Tone.Transport.scheduleOnce(() => s.triggerAttackRelease(item.note, item.duration), `+${t}`);
+        }
+        t += item.duration;
+    }
+    Tone.Transport.start();
+}

--- a/SMOKE_TEST.md
+++ b/SMOKE_TEST.md
@@ -7,6 +7,37 @@ Admin: `lucas.decarli.ca@gmail.com` / `Admin!LocalDev1`
 
 ---
 
+## 0. Anti-cheat de áudio (NEW)
+
+Para os 7 exercícios em escopo: **GuessNote, GuessChords, GuessFunction,
+GuessInterval, GuessFullInterval, GuessQuality, GuessMissingNote**.
+
+DevTools → **Network**, filtrar por `audio` ou por `Exercise`:
+
+- [ ] `POST /Exercise/RequestPlay` na resposta tem **somente** `roundId` + `playToken` (ou `melody1Token` + `melody2Token` para GuessMissingNote). Nenhum dos campos a seguir aparece: `note`, `notes`, `note1`, `note2`, `root`, `quality`, `type`, `melody1`, `melody2`, `answer`.
+- [ ] Não existe nenhum request a `/audio/C4.mp3`, `/audio/Cs4.mp3`, etc. — apenas `/audio/token/<guid>`.
+- [ ] A URL em `/audio/token/<guid>` é um GUID hex de 32 caracteres (não um nome de nota).
+- [ ] `Replay` re-toca sem novo download (buffer cacheado em memória pelo `AudioEngine`).
+
+DevTools → **Console**:
+
+- [ ] `window.currentChordNotes` é `undefined`.
+- [ ] No estado de "esperando resposta" não existe nenhuma variável global ou local exposta com o nome da nota / acorde / intervalo.
+
+DevTools → **Application/Storage**:
+
+- [ ] Nenhum cache HTTP guarda o áudio do round (`Cache-Control: no-store` no response de `/audio/token/...`).
+
+Após **Validate**:
+
+- [ ] Resposta JSON inclui `answer` correto — pedagógico, esperado.
+- [ ] Mesmo `roundId` enviado de novo → `success:false` com `Exercise.SessionExpired` (round consumido).
+
+Sheet-music exercises (fora de escopo, devem continuar funcionando):
+
+- [ ] **IntervalMelodico** ainda toca via Sampler legado (notas conhecidas pelo browser por design).
+- [ ] **SolfegeMelody** ainda renderiza partitura corretamente.
+
 ## 1. Idioma & Tema (header)
 - [X] Switcher de idioma no header alterna **EN / FR-CA / PT-BR** e persiste após reload
 - [X] Toggle dark/light no header alterna tema e persiste após reload

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -107,3 +107,6 @@ output sqlDatabaseName string = stack.outputs.sqlDatabaseName
 output managedIdentityClientId string = stack.outputs.managedIdentityClientId
 output managedIdentityPrincipalId string = stack.outputs.managedIdentityPrincipalId
 output applicationInsightsConnectionString string = stack.outputs.applicationInsightsConnectionString
+output storageAccountName string = stack.outputs.storageAccountName
+output storageBlobEndpoint string = stack.outputs.storageBlobEndpoint
+output audioBaseUrl string = stack.outputs.audioBaseUrl

--- a/infra/modules/containerapp.bicep
+++ b/infra/modules/containerapp.bicep
@@ -22,6 +22,9 @@ param memory string = '1.0Gi'
 @description('Bootstrap admin email for the application (Admin__Email).')
 param adminEmail string = ''
 
+@description('Storage account blob endpoint (e.g. https://staaprd...blob.core.windows.net/).')
+param storageBlobEndpoint string = ''
+
 // SQL connection string built from outputs. AAD auth via the user-assigned MI.
 // User Id=<MI clientId> is required for Active Directory Default to pick the right identity in a multi-MI host.
 var sqlConnectionString = 'Server=tcp:${sqlServerFqdn},1433;Initial Catalog=${sqlDatabaseName};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Authentication=Active Directory Default;User Id=${managedIdentityClientId}'
@@ -52,6 +55,7 @@ var staticEnv = [
   { name: 'ApplicationInsights__ConnectionString', value: appInsightsConnectionString }
   { name: 'SqlConnection__Default', value: sqlConnectionString }
   { name: 'Admin__Email', value: adminEmail }
+  { name: 'Storage__BlobEndpoint', value: storageBlobEndpoint }
 ]
 
 var secretEnv = [for s in kvSecrets: {

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -1,0 +1,138 @@
+// Storage account for Academia Auditiva audio assets and exercise logs.
+// Containers:
+//   - piano-audio          : private (source mp3 sample bank, accessed via MI)
+//   - piano-audio-mixed    : private (server-mixed per-round clips, 1h lifecycle)
+//   - piano-audio-crypto   : private (legacy — kept until consumers retire)
+//   - exercice-logs        : private (server-only writes)
+//
+// The Container App's user-assigned MI receives "Storage Blob Data Contributor"
+// so the app can read source mp3s, write mixed blobs, and write logs without keys.
+
+param name string
+param location string
+param tags object
+param managedIdentityPrincipalId string
+
+@description('Built-in role: Storage Blob Data Contributor')
+var blobContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+resource sa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: true
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+    publicNetworkAccess: 'Enabled'
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Allow'
+    }
+  }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+  parent: sa
+  name: 'default'
+  properties: {
+    cors: {
+      corsRules: [
+        {
+          allowedOrigins: [ '*' ]
+          allowedMethods: [ 'GET', 'HEAD', 'OPTIONS' ]
+          allowedHeaders: [ '*' ]
+          exposedHeaders: [ '*' ]
+          maxAgeInSeconds: 3600
+        }
+      ]
+    }
+  }
+}
+
+resource pianoAudio 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'piano-audio'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+// Per-round mixed audio clips written by AudioMixerService. The blob
+// name is a content hash (mix-{sha256}.wav), so identical rounds reuse
+// the same blob. The lifecycle rule below deletes anything in this
+// container that hasn't been touched for a day (Azure lifecycle has
+// day-level granularity); plenty for a 15-min round TTL.
+resource pianoAudioMixed 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'piano-audio-mixed'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource mixedLifecycle 'Microsoft.Storage/storageAccounts/managementPolicies@2023-05-01' = {
+  parent: sa
+  name: 'default'
+  properties: {
+    policy: {
+      rules: [
+        {
+          enabled: true
+          name: 'delete-mixed-after-1h'
+          type: 'Lifecycle'
+          definition: {
+            actions: {
+              baseBlob: {
+                delete: {
+                  daysAfterModificationGreaterThan: 1
+                }
+              }
+            }
+            filters: {
+              blobTypes: [ 'blockBlob' ]
+              prefixMatch: [ 'piano-audio-mixed/' ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource pianoAudioCrypto 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'piano-audio-crypto'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource exerciceLogs 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'exercice-logs'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource miBlobContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: sa
+  name: guid(sa.id, managedIdentityPrincipalId, blobContributorRoleId)
+  properties: {
+    principalId: managedIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', blobContributorRoleId)
+  }
+}
+
+output id string = sa.id
+output name string = sa.name
+output blobEndpoint string = sa.properties.primaryEndpoints.blob
+output pianoAudioBaseUrl string = '${sa.properties.primaryEndpoints.blob}piano-audio/'

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -29,6 +29,7 @@ var logAnalyticsName = 'log-${nameBase}'
 var appInsightsName = 'appi-${nameBase}'
 var containerAppEnvName = 'cae-${nameBase}'
 var containerAppName = 'ca-${nameBase}'
+var storageAccountName = take('st${nameBaseFlat}${unique6}', 24)
 
 // -----------------------------------------------------------------------------
 // Identity
@@ -107,6 +108,20 @@ module sql 'modules/sql.bicep' = {
 }
 
 // -----------------------------------------------------------------------------
+// Storage (audio assets + exercise logs)
+// -----------------------------------------------------------------------------
+
+module storage 'modules/storage.bicep' = {
+  name: 'storage'
+  params: {
+    name: storageAccountName
+    location: location
+    tags: tags
+    managedIdentityPrincipalId: identity.outputs.principalId
+  }
+}
+
+// -----------------------------------------------------------------------------
 // Container Apps
 // -----------------------------------------------------------------------------
 
@@ -139,6 +154,7 @@ module containerApp 'modules/containerapp.bicep' = {
     minReplicas: containerAppMinReplicas
     maxReplicas: containerAppMaxReplicas
     adminEmail: aadAdminLogin
+    storageBlobEndpoint: storage.outputs.blobEndpoint
   }
 }
 
@@ -155,3 +171,6 @@ output sqlDatabaseName string = sql.outputs.databaseName
 output managedIdentityClientId string = identity.outputs.clientId
 output managedIdentityPrincipalId string = identity.outputs.principalId
 output applicationInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString
+output storageAccountName string = storage.outputs.name
+output storageBlobEndpoint string = storage.outputs.blobEndpoint
+output audioBaseUrl string = storage.outputs.pianoAudioBaseUrl


### PR DESCRIPTION
Replaces plaintext-note audio playback in the 7 audio-only exercises (GuessNote/Chords/Function/Interval/FullInterval/Quality/MissingNote) with per-round opaque tokens so DevTools/Network cannot reveal answers.

## Highlights
- Backend mixes per-question audio into a single WAV (NLayer mp3 decode + summing) in `piano-audio-mixed` container, content-hash cached.
- `RequestPlay` returns `{roundId, playToken}` (or two tokens for GuessMissingNote). `ValidateExercise` looks up by roundId and returns the correct answer after the round closes (so the user still sees what was right/wrong).
- `GET /audio/token/{token}` streams opaque bytes, scoped to the issuing user.
- Tone.js front uses BufferSource + decodeAudioData with in-memory buffer cache for replay.
- Sheet-music exercises (IntervalMelodico/SolfegeMelody) keep the legacy Sampler path — identity is already visible to the learner by design.
- Rate limiter: 60/min RequestPlay, 600/min /audio/token.

## Infra
- New `piano-audio-mixed` container (private, 1-day lifecycle).
- `Storage__BlobEndpoint` piped into the container app.
- `piano-audio` retained at user's request.

## Verification
- Build green: 0 errors, 101 warnings.
- Backend tests blocked locally (arm64 .NET 8 runtime missing); CI `ci.yml` will exercise the existing suite.
- End-to-end smoke (browser playback + Tone decode of the mixer WAV) intentionally deferred to Azure smoke testing — see `SMOKE_TEST.md` section 0 for the checklist.

## Out of scope (follow-ups)
- New unit/integration tests for `AudioTokenService` / `AudioMixerService` / `ExercisePlaybackPlanner` / `ExerciseController`.
- Swap `AddDistributedMemoryCache` for Redis when scaling out replicas.