### PR TITLE
fix(infra): stop clobbering ConnectionStrings--DefaultConnection on every deploy

### DIFF
--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -61,8 +61,17 @@ resource kvAdminOfficer 'Microsoft.Authorization/roleAssignments@2022-04-01' = i
 
 // Placeholder secrets so the Container App can wire references on first deploy.
 // Real values are written later via infra/scripts/seed-keyvault.ps1.
+//
+// IMPORTANT: This Bicep does **not** include ConnectionStrings--DefaultConnection
+// in the placeholder list. Doing so would clobber the real SQL connection string
+// on every redeploy (the placeholder is just 'placeholder-set-via-seed-script',
+// 31 characters, which then fails Migrate() at startup with
+// "Format of the initialization string does not conform to specification").
+// The SQL connection string is constructed deterministically in
+// modules/containerapp.bicep from the SQL outputs and exposed both as the
+// SqlConnection__Default env var and (via that module) as the
+// connectionstrings--defaultconnection KV-backed secret.
 var placeholderSecretNames = [
-  'ConnectionStrings--DefaultConnection'
   'Facebook--AppId'
   'Facebook--AppSecret'
   'Smtp--Host'

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -125,6 +125,24 @@ module storage 'modules/storage.bicep' = {
 // Container Apps
 // -----------------------------------------------------------------------------
 
+// Write the SQL connection string to KV deterministically. Built from the
+// same parts the container app would use; keeping this resource here (rather
+// than as a placeholder in modules/keyvault.bicep) means redeploys do not
+// clobber an externally-rotated value with a placeholder, and the value is
+// always in sync with the SQL outputs.
+resource sqlConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  name: '${keyVaultName}/ConnectionStrings--DefaultConnection'
+  properties: {
+    value: 'Server=tcp:${sql.outputs.serverFqdn},1433;Initial Catalog=${sql.outputs.databaseName};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Authentication=Active Directory Default;User Id=${identity.outputs.clientId}'
+    contentType: 'text/plain'
+  }
+  dependsOn: [
+    keyvault
+    sql
+    identity
+  ]
+}
+
 module caeEnv 'modules/containerapp-env.bicep' = {
   name: 'cae-env'
   params: {
@@ -156,6 +174,9 @@ module containerApp 'modules/containerapp.bicep' = {
     adminEmail: aadAdminLogin
     storageBlobEndpoint: storage.outputs.blobEndpoint
   }
+  dependsOn: [
+    sqlConnectionStringSecret
+  ]
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Root cause of the prod outage on revision 0000004 of ca-aa-prd: the keyvault module unconditionally recreated `ConnectionStrings--DefaultConnection` with the placeholder `'placeholder-set-via-seed-script'` (31 chars) on every Bicep deploy. After someone seeded the real value once, every subsequent `azd provision` silently overwrote it. The container app's KV secret reference then pulled 31 chars at next replica restart and crashed in `Database.Migrate()` with `Format of the initialization string does not conform to specification starting at index 0`.

## Changes
- `infra/modules/keyvault.bicep`: drop `ConnectionStrings--DefaultConnection` from `placeholderSecretNames` (Facebook/SMTP still seeded by the script).
- `infra/resources.bicep`: write the SQL connection string as a real, deterministic KV secret derived from the SQL outputs + MI clientId. Container app now depends on the secret existing.

## Verification
Hotfix already applied manually to prod at 19:30 UTC: `az keyvault secret set ConnectionStrings--DefaultConnection` then revision restart. Revision `ca-aa-prd--0000004` now Healthy / Running, `/health/ready` returns 200. This PR makes the fix permanent so the next deploy does not regress.