### PR TITLE
fix(audio): restore AudioEngine.initSampler as no-op for legacy bootstrap

### DIFF
--- a/AcademiaAuditiva/wwwroot/js/core/audio-engine.js
+++ b/AcademiaAuditiva/wwwroot/js/core/audio-engine.js
@@ -156,6 +156,13 @@ const AudioEngine = (() => {
         preload,
         stop,
         setupWaveform,
+        // No-op for backward compat. The legacy bootstrap calls
+        // AudioEngine.initSampler() on every page load; the new flow
+        // builds the sampler lazily on first legacy playback (see
+        // __initLegacySampler) and the token flow doesn't need it at
+        // all. Keeping this method as a no-op avoids a TypeError on
+        // page init for callers we haven't migrated.
+        initSampler: () => {},
         // === Legacy API ===
         // Used only by the sheet-music exercises (IntervalMelodico,
         // and SolfegeMelody if it grows playback) where the note name


### PR DESCRIPTION
academia-auditiva.js calls AudioEngine.initSampler() on every page DOMContentLoaded. The audio-engine rewrite dropped it from the public API, so every page threw 'AudioEngine.initSampler is not a function' and bricked all client JS (including the new Guess*.js play handlers).

Add a no-op stub. The legacy sampler is still built lazily on first legacy playback (sheet-music exercises); the token flow doesn't touch it.