### PR TITLE
fix(audio): use Tone.ToneBufferSource for token playback

### DIFF
--- a/AcademiaAuditiva/Views/Shared/_Layout.cshtml
+++ b/AcademiaAuditiva/Views/Shared/_Layout.cshtml
@@ -188,7 +188,7 @@
     <script src="/js/dist/essentia.js-model.js?v=1.0.2"></script>
     <script src="/js/dist/essentia.js-plot.js?v=1.0.2"></script>
     <script src="/js/dist/essentia-wasm.web.js?v=1.0.2"></script>
-    <script src="/js/core/audio-engine.js?v=1.0.4"></script>
+    <script src="/js/core/audio-engine.js?v=1.0.5"></script>
     <script src="/js/games/game-engine.js?v=1.0.2"></script>
     <script src="/js/main/academia-auditiva.js?v=1.0.2"></script>
     <script src="/js/AcademiaAuditiva.Filters.js?v=1.0.2"></script>

--- a/AcademiaAuditiva/wwwroot/js/core/audio-engine.js
+++ b/AcademiaAuditiva/wwwroot/js/core/audio-engine.js
@@ -71,13 +71,12 @@ const AudioEngine = (() => {
 
         stop();
 
-        // Use a raw BufferSource — Tone.Player would also work, but
-        // BufferSource is the lowest-friction primitive for "play this
-        // exact buffer once" and keeps the destination wired through
-        // Tone.Destination so setupWaveform's analyser still observes it.
-        const source = Tone.context.createBufferSource();
-        source.buffer = buffer;
-        source.connect(Tone.Destination.input ?? Tone.Destination);
+        // Use Tone.ToneBufferSource so the node integrates with the Tone
+        // graph (and setupWaveform's analyser, which is wired off
+        // Tone.Destination). A native createBufferSource() can't connect
+        // to Tone.Destination directly — Tone's internal lookup throws
+        // "A value with the given key could not be found".
+        const source = new Tone.ToneBufferSource(buffer).toDestination();
         currentSource = source;
 
         return new Promise((resolve) => {


### PR DESCRIPTION
Fixes runtime error in playToken: 'A value with the given key could not be found'. Native AudioBufferSourceNode cannot connect to Tone.Destination. Switched to Tone.ToneBufferSource so the node integrates with the Tone graph (and setupWaveform's analyser). Bumps cache-buster to v1.0.5.